### PR TITLE
Fix to allow null es_root_parent_id input

### DIFF
--- a/data.subscription.tf
+++ b/data.subscription.tf
@@ -1,0 +1,3 @@
+# Get the current Subscription context
+data "azurerm_subscription" "current" {
+}

--- a/locals.tf
+++ b/locals.tf
@@ -11,7 +11,7 @@ locals {
 locals {
   es_root_id                    = var.es_root_id
   es_root_name                  = var.es_root_name
-  es_root_parent_id             = var.es_root_parent_id
+  es_root_parent_id             = var.es_root_parent_id != null ? var.es_root_parent_id : data.azurerm_subscription.current.tenant_id
   es_deploy_core_landing_zones  = var.es_deploy_core_landing_zones
   es_archetype_config_overrides = var.es_archetype_config_overrides
   es_subscription_ids_overrides = var.es_subscription_ids_overrides

--- a/resources.management_groups.tf
+++ b/resources.management_groups.tf
@@ -15,7 +15,7 @@ resource "azurerm_management_group" "level_1" {
 
   name                       = each.value.id
   display_name               = each.value.display_name
-  parent_management_group_id = try(length(each.value.parent_management_group_id) > 0, false) ? "${local.provider_path.management_groups}${each.value.parent_management_group_id}" : local.empty_string
+  parent_management_group_id = try(length(each.value.parent_management_group_id) > 0, false) ? "${local.provider_path.management_groups}${each.value.parent_management_group_id}" : "${local.provider_path.management_groups}${local.es_root_parent_id}"
   subscription_ids           = each.value.subscription_ids
 
 }
@@ -29,7 +29,7 @@ resource "azurerm_management_group" "level_2" {
 
   name                       = each.value.id
   display_name               = each.value.display_name
-  parent_management_group_id = azurerm_management_group.level_1["${local.provider_path.management_groups}${each.value.parent_management_group_id}"].id
+  parent_management_group_id = "${local.provider_path.management_groups}${each.value.parent_management_group_id}"
   subscription_ids           = each.value.subscription_ids
 
   depends_on = [azurerm_management_group.level_1]
@@ -45,7 +45,7 @@ resource "azurerm_management_group" "level_3" {
 
   name                       = each.value.id
   display_name               = each.value.display_name
-  parent_management_group_id = azurerm_management_group.level_2["${local.provider_path.management_groups}${each.value.parent_management_group_id}"].id
+  parent_management_group_id = "${local.provider_path.management_groups}${each.value.parent_management_group_id}"
   subscription_ids           = each.value.subscription_ids
 
   depends_on = [azurerm_management_group.level_2]
@@ -61,7 +61,7 @@ resource "azurerm_management_group" "level_4" {
 
   name                       = each.value.id
   display_name               = each.value.display_name
-  parent_management_group_id = azurerm_management_group.level_3["${local.provider_path.management_groups}${each.value.parent_management_group_id}"].id
+  parent_management_group_id = "${local.provider_path.management_groups}${each.value.parent_management_group_id}"
   subscription_ids           = each.value.subscription_ids
 
   depends_on = [azurerm_management_group.level_3]
@@ -77,7 +77,7 @@ resource "azurerm_management_group" "level_5" {
 
   name                       = each.value.id
   display_name               = each.value.display_name
-  parent_management_group_id = azurerm_management_group.level_4["${local.provider_path.management_groups}${each.value.parent_management_group_id}"].id
+  parent_management_group_id = "${local.provider_path.management_groups}${each.value.parent_management_group_id}"
   subscription_ids           = each.value.subscription_ids
 
   depends_on = [azurerm_management_group.level_4]
@@ -93,7 +93,7 @@ resource "azurerm_management_group" "level_6" {
 
   name                       = each.value.id
   display_name               = each.value.display_name
-  parent_management_group_id = azurerm_management_group.level_5["${local.provider_path.management_groups}${each.value.parent_management_group_id}"].id
+  parent_management_group_id = "${local.provider_path.management_groups}${each.value.parent_management_group_id}"
   subscription_ids           = each.value.subscription_ids
 
   depends_on = [azurerm_management_group.level_5]


### PR DESCRIPTION
This PR fixes a bug where providing a null value for es_root_parent_id causes a deployment failure.

Null will now default to the tenant ID representing the `Tenant Root Group` Management Group.