### PR TITLE
Adding dependencies on MG before policies assignment

### DIFF
--- a/resources.policy_assignments.tf
+++ b/resources.policy_assignments.tf
@@ -24,6 +24,13 @@ resource "azurerm_policy_assignment" "enterprise_scale" {
   depends_on = [
     azurerm_policy_definition.enterprise_scale,
     azurerm_policy_set_definition.enterprise_scale,
+    azurerm_management_group.level_1,
+    azurerm_management_group.level_2,
+    azurerm_management_group.level_3,
+    azurerm_management_group.level_4,
+    azurerm_management_group.level_5,
+    azurerm_management_group.level_6,
+  
   ]
 
 }

--- a/resources.policy_assignments.tf
+++ b/resources.policy_assignments.tf
@@ -22,15 +22,14 @@ resource "azurerm_policy_assignment" "enterprise_scale" {
 
   # Set explicit dependency on Policy Definition and Policy Set Definition deployments
   depends_on = [
-    azurerm_policy_definition.enterprise_scale,
-    azurerm_policy_set_definition.enterprise_scale,
     azurerm_management_group.level_1,
     azurerm_management_group.level_2,
     azurerm_management_group.level_3,
     azurerm_management_group.level_4,
     azurerm_management_group.level_5,
     azurerm_management_group.level_6,
-  
+    azurerm_policy_definition.enterprise_scale,
+    azurerm_policy_set_definition.enterprise_scale,  
   ]
 
 }

--- a/resources.policy_assignments.tf
+++ b/resources.policy_assignments.tf
@@ -29,7 +29,7 @@ resource "azurerm_policy_assignment" "enterprise_scale" {
     azurerm_management_group.level_5,
     azurerm_management_group.level_6,
     azurerm_policy_definition.enterprise_scale,
-    azurerm_policy_set_definition.enterprise_scale,  
+    azurerm_policy_set_definition.enterprise_scale,
   ]
 
 }


### PR DESCRIPTION
When you are deploying custom management with policy assignments, the graph will start assignments at the same time as management groups. Adding dependency to make sure MG gets created first. 
