### PR TITLE
Fixed instructions for subscription mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ module "enterprise_scale" {
     #------------------------------------------------------#
   }
 
-  es_subscription_ids_map = {
+  subscription_id_overrides = {
     #------------------------------------------------------#
     # This variable is used to associate Azure subscription_ids
     # with the built-in Enterprise-scale Management Groups.

--- a/locals.management_groups.tf
+++ b/locals.management_groups.tf
@@ -82,7 +82,7 @@ locals {
 # should be assigned to the core Enterprise-scale Management
 # Groups. To ensure a valid value is always provided, we
 # provide a list of defaults in es_subscription_ids_defaults which
-# can be overridden using the es_subscription_ids_map variable.
+# can be overridden using the subscription_id_overrides variable.
 locals {
   es_subscription_ids_defaults = {
     (local.root_id)                   = local.empty_list


### PR DESCRIPTION
When using the sample code in the readme, the parameter for subscription mapping would throw an error for not being required. Looked into the module and found the variable was incorrect, was `es_subscription_ids_map` and needed to be `subscription_id_overrides` as the map is a local and not a variable. 