### PR TITLE
Allow the creation of GatewaySubnets and AzureFirewallSubnets without NSGs

### DIFF
--- a/modules/archetypes/lib/policy_definitions/policy_definition_es_deny_subnet_without_nsg.json
+++ b/modules/archetypes/lib/policy_definitions/policy_definition_es_deny_subnet_without_nsg.json
@@ -17,6 +17,14 @@
           {
             "field": "Microsoft.Network/virtualNetworks/subnets/networkSecurityGroup.id",
             "exists": "false"
+          },
+          {
+            "field": "name",
+            "notEquals": "GatewaySubnet"
+          },
+          {
+            "field": "name",
+            "notEquals": "AzureFirewallSubnet"
           }
         ]
       },


### PR DESCRIPTION
Azure does not permit the creation of a GatewaySubnet or AzureFirewallSubnet with a NSG.
