### PR TITLE
Adds required_providers configuration block

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -1,0 +1,14 @@
+# Configure the minimum required providers supported by this module
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = ">= 2.34.0"
+    }
+    time = {
+      source  = "hashicorp/time"
+      version = ">= 0.7.0"
+    }
+  }
+}


### PR DESCRIPTION
Adds an internal `required_providers` configuration block to ensure the module is deployed using at least the minimum required provider versions, as per:

> If you are writing a shared Terraform module, constrain only the minimum required provider version using a `>=` constraint.
>This should specify the minimum version containing the features your module relies on, and thus allow a user of your module to potentially select a newer provider version if other features are needed by other parts of their overall configuration.

https://www.terraform.io/docs/language/modules/develop/providers.html#provider-version-constraints-in-modules