### PR TITLE
Patch Policy Issues

### DIFF
--- a/.github/scripts/EnterpriseScaleLibraryTools/EnterpriseScaleLibraryTools.psm1
+++ b/.github/scripts/EnterpriseScaleLibraryTools/EnterpriseScaleLibraryTools.psm1
@@ -515,7 +515,7 @@ class ArmTemplateResource : ESLTBase {
             foreach ($policyDefinition in $this.properties.policyDefinitions) {
                 $regexMatches = [ArmTemplateResource]::regexExtractProviderId.Matches($policyDefinition.policyDefinitionId)
                 if ($regexMatches.Index -gt 0) {
-                    $policyDefinition.policyDefinitionId = "`${current_scope_resource_id}$($regexMatches.Value)"
+                    $policyDefinition.policyDefinitionId = "`${root_scope_resource_id}$($regexMatches.Value)"
                 }
                 else {
                     $policyDefinition.policyDefinitionId = $regexMatches.Value

--- a/locals.policy_assignments.tf
+++ b/locals.policy_assignments.tf
@@ -90,7 +90,7 @@ data "azurerm_policy_set_definition" "external_lookup" {
 locals {
   policy_definitions_ids_from_internal_policy_set_definitions = {
     for policy_set_definition in local.es_policy_set_definitions :
-    policy_set_definition.resource_id => try(policy_set_definition.template.policyDefinitions.*.policyDefinitionId, local.empty_list)
+    policy_set_definition.resource_id => try(policy_set_definition.template.properties.policyDefinitions.*.policyDefinitionId, local.empty_list)
   }
   policy_definitions_ids_from_external_policy_set_definitions = {
     for policy_set_definition_id, policy_set_definition_config in data.azurerm_policy_set_definition.external_lookup :

--- a/locals.policy_assignments.tf
+++ b/locals.policy_assignments.tf
@@ -56,13 +56,17 @@ locals {
   # Policy Definitions
   policy_assignments_with_managed_identity_using_external_policy_definition = {
     for policy_assignment_id, policy_definition_id in local.policy_assignments_with_managed_identity :
-    policy_assignment_id => policy_definition_id
+    policy_assignment_id => [
+      policy_definition_id,
+    ]
     if length(regexall(local.resource_types.policy_definition, policy_definition_id)) > 0 && contains(local.internal_policy_definition_ids, policy_definition_id) != true
   }
   # Policy Set Definitions
   policy_assignments_with_managed_identity_using_external_policy_set_definition = {
     for policy_assignment_id, policy_set_definition_id in local.policy_assignments_with_managed_identity :
-    policy_assignment_id => policy_set_definition_id
+    policy_assignment_id => [
+      policy_set_definition_id,
+    ]
     if length(regexall(local.resource_types.policy_set_definition, policy_set_definition_id)) > 0 && contains(local.internal_policy_set_definition_ids, policy_set_definition_id) != true
   }
 }
@@ -70,7 +74,7 @@ locals {
 # Generate list of Policy Set Definitions to lookup from Azure.
 locals {
   azurerm_policy_set_definition_external_lookup = {
-    for policy_set_definition_id in local.policy_assignments_with_managed_identity_using_external_policy_set_definition :
+    for policy_set_definition_id in keys(transpose(local.policy_assignments_with_managed_identity_using_external_policy_set_definition)) :
     policy_set_definition_id => {
       name                  = basename(policy_set_definition_id)
       management_group_name = try(regex(local.regex_extract_provider_scope, policy_set_definition_id), null)
@@ -88,49 +92,49 @@ data "azurerm_policy_set_definition" "external_lookup" {
 
 # Create a list of Policy Definitions IDs used by all assigned Policy Set Definitions
 locals {
-  policy_definitions_ids_from_internal_policy_set_definitions = {
+  policy_definition_ids_from_internal_policy_set_definitions = {
     for policy_set_definition in local.es_policy_set_definitions :
     policy_set_definition.resource_id => [
       for policy_definition in policy_set_definition.template.properties.policyDefinitions :
       policy_definition.policyDefinitionId
     ]
   }
-  policy_definitions_ids_from_external_policy_set_definitions = {
+  policy_definition_ids_from_external_policy_set_definitions = {
     for policy_set_definition_id, policy_set_definition_config in data.azurerm_policy_set_definition.external_lookup :
     policy_set_definition_id => [
       for policy_definition in policy_set_definition_config.policy_definition_reference :
       policy_definition.policy_definition_id
     ]
   }
-  policy_definitions_ids_from_policy_set_definitions = merge(
-    local.policy_definitions_ids_from_internal_policy_set_definitions,
-    local.policy_definitions_ids_from_external_policy_set_definitions,
+  policy_definition_ids_from_policy_set_definitions = merge(
+    local.policy_definition_ids_from_internal_policy_set_definitions,
+    local.policy_definition_ids_from_external_policy_set_definitions,
   )
 }
 
 # Identify all Policy Definitions which are external to this module
 locals {
   # From Policy Assignments using Policy Set Definitions
-  external_policy_definitions_ids_from_policy_set_definitions = distinct(flatten([
-    for policy_definitions in values(local.policy_definitions_ids_from_policy_set_definitions) : [
-      for policy_definition in policy_definitions :
-      policy_definition
-      if contains(local.internal_policy_definition_ids, policy_definition) != true
+  external_policy_definition_ids_from_policy_set_definitions = distinct(flatten([
+    for policy_definition_ids in values(local.policy_definition_ids_from_policy_set_definitions) : [
+      for policy_definition_id in policy_definition_ids :
+      policy_definition_id
+      if contains(local.internal_policy_definition_ids, policy_definition_id) != true
     ]
   ]))
   external_policy_definitions_from_azurerm_policy_set_definition_external_lookup = {
-    for policy_set_definition_id in local.external_policy_definitions_ids_from_policy_set_definitions :
-    policy_set_definition_id => {
-      name                  = basename(policy_set_definition_id)
-      management_group_name = try(regex(local.regex_extract_provider_scope, policy_set_definition_id), null)
+    for policy_definition_id in local.external_policy_definition_ids_from_policy_set_definitions :
+    policy_definition_id => {
+      name                  = basename(policy_definition_id)
+      management_group_name = try(regex(local.regex_extract_provider_scope, policy_definition_id), null)
     }
   }
   # From Policy Assignments using Policy Definitions
   external_policy_definitions_from_internal_policy_assignments = {
-    for policy_set_definition_id in local.policy_assignments_with_managed_identity_using_external_policy_definition :
-    policy_set_definition_id => {
-      name                  = basename(policy_set_definition_id)
-      management_group_name = try(regex(local.regex_extract_provider_scope, policy_set_definition_id), null)
+    for policy_definition_id in keys(transpose(local.policy_assignments_with_managed_identity_using_external_policy_definition)) :
+    policy_definition_id => {
+      name                  = basename(policy_definition_id)
+      management_group_name = try(regex(local.regex_extract_provider_scope, policy_definition_id), null)
     }
   }
   # Then create a single list containing all Policy Definitions to lookup from Azure
@@ -184,7 +188,7 @@ locals {
 # of roles for each.
 locals {
   policy_set_definition_roles = {
-    for policy_set_definition_id, policy_definition_ids in local.policy_definitions_ids_from_policy_set_definitions :
+    for policy_set_definition_id, policy_definition_ids in local.policy_definition_ids_from_policy_set_definitions :
     policy_set_definition_id => distinct(flatten([
       for policy_definition_id in policy_definition_ids :
       local.policy_definition_roles[policy_definition_id]

--- a/locals.policy_assignments.tf
+++ b/locals.policy_assignments.tf
@@ -90,13 +90,16 @@ data "azurerm_policy_set_definition" "external_lookup" {
 locals {
   policy_definitions_ids_from_internal_policy_set_definitions = {
     for policy_set_definition in local.es_policy_set_definitions :
-    policy_set_definition.resource_id => try(policy_set_definition.template.properties.policyDefinitions.*.policyDefinitionId, local.empty_list)
+    policy_set_definition.resource_id => [
+      for policy_definition in policy_set_definition.template.properties.policyDefinitions :
+      policy_definition.policyDefinitionId
+    ]
   }
   policy_definitions_ids_from_external_policy_set_definitions = {
     for policy_set_definition_id, policy_set_definition_config in data.azurerm_policy_set_definition.external_lookup :
     policy_set_definition_id => [
-      for policy_definition_reference in policy_set_definition_config.policy_definition_reference :
-      policy_definition_reference.policy_definition_id
+      for policy_definition in policy_set_definition_config.policy_definition_reference :
+      policy_definition.policy_definition_id
     ]
   }
   policy_definitions_ids_from_policy_set_definitions = merge(

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_asc_monitoring.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_asc_monitoring.tmpl.json
@@ -83,6 +83,6 @@
   },
   "location": "${default_location}",
   "identity": {
-    "type": "SystemAssigned"
+    "type": "None"
   }
 }

--- a/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_deny_publicendpoints.tmpl.json
+++ b/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_deny_publicendpoints.tmpl.json
@@ -120,7 +120,7 @@
     "policyDefinitions": [
       {
         "policyDefinitionReferenceId": "CosmosDenyPaasPublicIP",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-CosmosDB",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-CosmosDB",
         "parameters": {
           "effect": {
             "value": "[parameters('CosmosPublicIpDenyEffect')]"
@@ -130,7 +130,7 @@
       },
       {
         "policyDefinitionReferenceId": "MariaDBDenyPaasPublicIP",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-MariaDB",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-MariaDB",
         "parameters": {
           "effect": {
             "value": "[parameters('MariaDBPublicIpDenyEffect')]"
@@ -140,7 +140,7 @@
       },
       {
         "policyDefinitionReferenceId": "MySQLDenyPaasPublicIP",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-MySQL",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-MySQL",
         "parameters": {
           "effect": {
             "value": "[parameters('MySQLPublicIpDenyEffect')]"
@@ -150,7 +150,7 @@
       },
       {
         "policyDefinitionReferenceId": "PostgreSQLDenyPaasPublicIP",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-PostgreSql",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-PostgreSql",
         "parameters": {
           "effect": {
             "value": "[parameters('PostgreSQLPublicIpDenyEffect')]"
@@ -160,7 +160,7 @@
       },
       {
         "policyDefinitionReferenceId": "KeyVaultDenyPaasPublicIP",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-KeyVault",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-KeyVault",
         "parameters": {
           "effect": {
             "value": "[parameters('KeyVaultPublicIpDenyEffect')]"
@@ -170,7 +170,7 @@
       },
       {
         "policyDefinitionReferenceId": "SqlServerDenyPaasPublicIP",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-Sql",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-Sql",
         "parameters": {
           "effect": {
             "value": "[parameters('SqlServerPublicIpDenyEffect')]"
@@ -180,7 +180,7 @@
       },
       {
         "policyDefinitionReferenceId": "StorageDenyPaasPublicIP",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-Storage",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-Storage",
         "parameters": {
           "effect": {
             "value": "[parameters('StoragePublicIpDenyEffect')]"
@@ -190,7 +190,7 @@
       },
       {
         "policyDefinitionReferenceId": "AKSDenyPaasPublicIP",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-Aks",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicEndpoint-Aks",
         "parameters": {
           "effect": {
             "value": "[parameters('AKSPublicIpDenyEffect')]"

--- a/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_deploy_diag_loganalytics.tmpl.json
+++ b/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_deploy_diag_loganalytics.tmpl.json
@@ -789,7 +789,7 @@
       },
       {
         "policyDefinitionReferenceId": "WVDAppGroupDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-WVDAppGroup",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-WVDAppGroup",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -805,7 +805,7 @@
       },
       {
         "policyDefinitionReferenceId": "WVDWorkspaceDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-WVDWorkspace",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-WVDWorkspace",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -821,7 +821,7 @@
       },
       {
         "policyDefinitionReferenceId": "WVDHostPoolsDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-WVDHostPools",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-WVDHostPools",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -837,7 +837,7 @@
       },
       {
         "policyDefinitionReferenceId": "ACIDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-ACI",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-ACI",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -853,7 +853,7 @@
       },
       {
         "policyDefinitionReferenceId": "ACRDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-ACR",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-ACR",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -869,7 +869,7 @@
       },
       {
         "policyDefinitionReferenceId": "AKSDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AKS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AKS",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -885,7 +885,7 @@
       },
       {
         "policyDefinitionReferenceId": "AnalysisServiceDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AnalysisService",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AnalysisService",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -901,7 +901,7 @@
       },
       {
         "policyDefinitionReferenceId": "APIforFHIRDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-ApiForFHIR",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-ApiForFHIR",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -917,7 +917,7 @@
       },
       {
         "policyDefinitionReferenceId": "APIMgmtDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-APIMgmt",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-APIMgmt",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -933,7 +933,7 @@
       },
       {
         "policyDefinitionReferenceId": "ApplicationGatewayDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-ApplicationGateway",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-ApplicationGateway",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -949,7 +949,7 @@
       },
       {
         "policyDefinitionReferenceId": "AutomationDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AA",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-AA",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -965,7 +965,7 @@
       },
       {
         "policyDefinitionReferenceId": "BatchDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-Batch",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-Batch",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -981,7 +981,7 @@
       },
       {
         "policyDefinitionReferenceId": "CDNEndpointsDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-CDNEndpoints",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-CDNEndpoints",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -997,7 +997,7 @@
       },
       {
         "policyDefinitionReferenceId": "CognitiveServicesDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-CognitiveServices",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-CognitiveServices",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1013,7 +1013,7 @@
       },
       {
         "policyDefinitionReferenceId": "CosmosDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-CosmosDB",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-CosmosDB",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1029,7 +1029,7 @@
       },
       {
         "policyDefinitionReferenceId": "DatabricksDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-Databricks",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-Databricks",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1045,7 +1045,7 @@
       },
       {
         "policyDefinitionReferenceId": "DataExplorerClusterDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DataExplorerCluster",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DataExplorerCluster",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1061,7 +1061,7 @@
       },
       {
         "policyDefinitionReferenceId": "DataFactoryDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DataFactory",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DataFactory",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1077,7 +1077,7 @@
       },
       {
         "policyDefinitionReferenceId": "DataLakeStoreDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DataLakeStore",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DataLakeStore",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1093,7 +1093,7 @@
       },
       {
         "policyDefinitionReferenceId": "DataLakeAnalyticsDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DLAnalytics",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-DLAnalytics",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1109,7 +1109,7 @@
       },
       {
         "policyDefinitionReferenceId": "EventGridSubDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-EventGridSub",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-EventGridSub",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1125,7 +1125,7 @@
       },
       {
         "policyDefinitionReferenceId": "EventGridTopicDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-EventGridTopic",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-EventGridTopic",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1141,7 +1141,7 @@
       },
       {
         "policyDefinitionReferenceId": "EventHubDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-EventHub",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-EventHub",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1157,7 +1157,7 @@
       },
       {
         "policyDefinitionReferenceId": "EventSystemTopicDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-EventGridSystemTopic",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-EventGridSystemTopic",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1173,7 +1173,7 @@
       },
       {
         "policyDefinitionReferenceId": "ExpressRouteDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-ExpressRoute",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-ExpressRoute",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1189,7 +1189,7 @@
       },
       {
         "policyDefinitionReferenceId": "FirewallDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-Firewall",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-Firewall",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1205,7 +1205,7 @@
       },
       {
         "policyDefinitionReferenceId": "FrontDoorDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-FrontDoor",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-FrontDoor",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1221,7 +1221,7 @@
       },
       {
         "policyDefinitionReferenceId": "FunctionAppDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-Function",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-Function",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1237,7 +1237,7 @@
       },
       {
         "policyDefinitionReferenceId": "HDInsightDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-HDInsight",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-HDInsight",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1253,7 +1253,7 @@
       },
       {
         "policyDefinitionReferenceId": "IotHubDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-iotHub",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-iotHub",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1269,7 +1269,7 @@
       },
       {
         "policyDefinitionReferenceId": "KeyVaultDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-KeyVault",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-KeyVault",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1285,7 +1285,7 @@
       },
       {
         "policyDefinitionReferenceId": "LoadBalancerDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-LoadBalancer",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-LoadBalancer",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1301,7 +1301,7 @@
       },
       {
         "policyDefinitionReferenceId": "LogicAppsISEDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-LogicAppsISE",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-LogicAppsISE",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1317,7 +1317,7 @@
       },
       {
         "policyDefinitionReferenceId": "LogicAppsWFDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-LogicAppsWF",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-LogicAppsWF",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1333,7 +1333,7 @@
       },
       {
         "policyDefinitionReferenceId": "MariaDBDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-MariaDB",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-MariaDB",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1349,7 +1349,7 @@
       },
       {
         "policyDefinitionReferenceId": "MediaServiceDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-MediaService",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-MediaService",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1365,7 +1365,7 @@
       },
       {
         "policyDefinitionReferenceId": "MlWorkspaceDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-MlWorkspace",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-MlWorkspace",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1381,7 +1381,7 @@
       },
       {
         "policyDefinitionReferenceId": "MySQLDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-MySQL",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-MySQL",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1397,7 +1397,7 @@
       },
       {
         "policyDefinitionReferenceId": "NetworkSecurityGroupsDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-NetworkSecurityGroups",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-NetworkSecurityGroups",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1413,7 +1413,7 @@
       },
       {
         "policyDefinitionReferenceId": "NetworkNICDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-NIC",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-NIC",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1429,7 +1429,7 @@
       },
       {
         "policyDefinitionReferenceId": "PostgreSQLDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-PostgreSQL",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-PostgreSQL",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1445,7 +1445,7 @@
       },
       {
         "policyDefinitionReferenceId": "PowerBIEmbeddedDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-PowerBIEmbedded",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-PowerBIEmbedded",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1461,7 +1461,7 @@
       },
       {
         "policyDefinitionReferenceId": "NetworkPublicIPNicDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-PublicIP",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-PublicIP",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1477,7 +1477,7 @@
       },
       {
         "policyDefinitionReferenceId": "RecoveryVaultDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-RecoveryVault",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-RecoveryVault",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1493,7 +1493,7 @@
       },
       {
         "policyDefinitionReferenceId": "RedisCacheDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-RedisCache",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-RedisCache",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1509,7 +1509,7 @@
       },
       {
         "policyDefinitionReferenceId": "RelayDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-Relay",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-Relay",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1525,7 +1525,7 @@
       },
       {
         "policyDefinitionReferenceId": "SearchServicesDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-SearchServices",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-SearchServices",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1541,7 +1541,7 @@
       },
       {
         "policyDefinitionReferenceId": "ServiceBusDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-ServiceBus",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-ServiceBus",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1557,7 +1557,7 @@
       },
       {
         "policyDefinitionReferenceId": "SignalRDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-SignalR",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-SignalR",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1573,7 +1573,7 @@
       },
       {
         "policyDefinitionReferenceId": "SQLDBsDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-SQLDBs",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-SQLDBs",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1589,7 +1589,7 @@
       },
       {
         "policyDefinitionReferenceId": "SQLElasticPoolsDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-SQLElasticPools",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-SQLElasticPools",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1605,7 +1605,7 @@
       },
       {
         "policyDefinitionReferenceId": "SQLMDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-SQLMI",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-SQLMI",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1621,7 +1621,7 @@
       },
       {
         "policyDefinitionReferenceId": "StreamAnalyticsDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-StreamAnalytics",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-StreamAnalytics",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1637,7 +1637,7 @@
       },
       {
         "policyDefinitionReferenceId": "TimeSeriesInsightsDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-TimeSeriesInsights",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-TimeSeriesInsights",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1653,7 +1653,7 @@
       },
       {
         "policyDefinitionReferenceId": "TrafficManagerDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-TrafficManager",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-TrafficManager",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1669,7 +1669,7 @@
       },
       {
         "policyDefinitionReferenceId": "VirtualNetworkDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VirtualNetwork",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VirtualNetwork",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1685,7 +1685,7 @@
       },
       {
         "policyDefinitionReferenceId": "VirtualMachinesDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VM",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VM",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1701,7 +1701,7 @@
       },
       {
         "policyDefinitionReferenceId": "VMSSDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VMSS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VMSS",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1717,7 +1717,7 @@
       },
       {
         "policyDefinitionReferenceId": "VNetGWDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VNetGW",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-VNetGW",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1733,7 +1733,7 @@
       },
       {
         "policyDefinitionReferenceId": "AppServiceDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-WebServerFarm",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-WebServerFarm",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"
@@ -1749,7 +1749,7 @@
       },
       {
         "policyDefinitionReferenceId": "AppServiceWebappDeployDiagnosticLogDeployLogAnalytics",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-Website",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-Website",
         "parameters": {
           "logAnalytics": {
             "value": "[parameters('logAnalytics')]"

--- a/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_deploy_sql_security.tmpl.json
+++ b/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_deploy_sql_security.tmpl.json
@@ -78,7 +78,7 @@
     "policyDefinitions": [
       {
         "policyDefinitionReferenceId": "SqlDbTdeDeploySqlSecurity",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Sql-Tde",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Sql-Tde",
         "parameters": {
           "effect": {
             "value": "[parameters('SqlDbTdeDeploySqlSecurityEffect')]"
@@ -88,7 +88,7 @@
       },
       {
         "policyDefinitionReferenceId": "SqlDbSecurityAlertPoliciesDeploySqlSecurity",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Sql-SecurityAlertPolicies",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Sql-SecurityAlertPolicies",
         "parameters": {
           "effect": {
             "value": "[parameters('SqlDbSecurityAlertPoliciesDeploySqlSecurityEffect')]"
@@ -98,7 +98,7 @@
       },
       {
         "policyDefinitionReferenceId": "SqlDbAuditingSettingsDeploySqlSecurity",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Sql-AuditingSettings",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Sql-AuditingSettings",
         "parameters": {
           "effect": {
             "value": "[parameters('SqlDbAuditingSettingsDeploySqlSecurityEffect')]"
@@ -108,7 +108,7 @@
       },
       {
         "policyDefinitionReferenceId": "SqlDbVulnerabilityAssessmentsDeploySqlSecurity",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Sql-vulnerabilityAssessments",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Sql-vulnerabilityAssessments",
         "parameters": {
           "effect": {
             "value": "[parameters('SqlDbVulnerabilityAssessmentsDeploySqlSecurityEffect')]"

--- a/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_enforce_encrypttransit.tmpl.json
+++ b/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_enforce_encrypttransit.tmpl.json
@@ -371,7 +371,7 @@
     "policyDefinitions": [
       {
         "policyDefinitionReferenceId": "AppServiceHttpEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Append-AppService-httpsonly",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Append-AppService-httpsonly",
         "parameters": {
           "effect": {
             "value": "[parameters('AppServiceHttpEffect')]"
@@ -381,7 +381,7 @@
       },
       {
         "policyDefinitionReferenceId": "AppServiceminTlsVersion",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Append-AppService-latestTLS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Append-AppService-latestTLS",
         "parameters": {
           "effect": {
             "value": "[parameters('AppServiceTlsVersionEffect')]"
@@ -424,7 +424,7 @@
       },
       {
         "policyDefinitionReferenceId": "APIAppServiceHttpsEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceApiApp-http",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceApiApp-http",
         "parameters": {
           "effect": {
             "value": "[parameters('APIAppServiceHttpsEffect')]"
@@ -434,7 +434,7 @@
       },
       {
         "policyDefinitionReferenceId": "FunctionServiceHttpsEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceFunctionApp-http",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceFunctionApp-http",
         "parameters": {
           "effect": {
             "value": "[parameters('FunctionServiceHttpsEffect')]"
@@ -444,7 +444,7 @@
       },
       {
         "policyDefinitionReferenceId": "WebAppServiceHttpsEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceWebApp-http",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-AppServiceWebApp-http",
         "parameters": {
           "effect": {
             "value": "[parameters('WebAppServiceHttpsEffect')]"
@@ -464,7 +464,7 @@
       },
       {
         "policyDefinitionReferenceId": "MySQLEnableSSLDeployEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-MySQL-sslEnforcement",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-MySQL-sslEnforcement",
         "parameters": {
           "effect": {
             "value": "[parameters('MySQLEnableSSLDeployEffect')]"
@@ -477,7 +477,7 @@
       },
       {
         "policyDefinitionReferenceId": "MySQLEnableSSLEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-MySql-http",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-MySql-http",
         "parameters": {
           "effect": {
             "value": "[parameters('MySQLEnableSSLEffect')]"
@@ -490,7 +490,7 @@
       },
       {
         "policyDefinitionReferenceId": "PostgreSQLEnableSSLDeployEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSql-sslEnforcement",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSql-sslEnforcement",
         "parameters": {
           "effect": {
             "value": "[parameters('PostgreSQLEnableSSLDeployEffect')]"
@@ -503,7 +503,7 @@
       },
       {
         "policyDefinitionReferenceId": "PostgreSQLEnableSSLEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PostgreSql-http",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PostgreSql-http",
         "parameters": {
           "effect": {
             "value": "[parameters('PostgreSQLEnableSSLEffect')]"
@@ -516,7 +516,7 @@
       },
       {
         "policyDefinitionReferenceId": "RedisTLSDeployEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Append-Redis-sslEnforcement",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Append-Redis-sslEnforcement",
         "parameters": {
           "effect": {
             "value": "[parameters('RedisTLSDeployEffect')]"
@@ -529,7 +529,7 @@
       },
       {
         "policyDefinitionReferenceId": "RedisdisableNonSslPort",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Append-Redis-disableNonSslPort",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Append-Redis-disableNonSslPort",
         "parameters": {
           "effect": {
             "value": "[parameters('RedisTLSDeployEffect')]"
@@ -539,7 +539,7 @@
       },
       {
         "policyDefinitionReferenceId": "RedisDenyhttps",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Redis-http",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Redis-http",
         "parameters": {
           "effect": {
             "value": "[parameters('RedisTLSEffect')]"
@@ -552,7 +552,7 @@
       },
       {
         "policyDefinitionReferenceId": "SQLManagedInstanceTLSDeployEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-SqlMi-minTLS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-SqlMi-minTLS",
         "parameters": {
           "effect": {
             "value": "[parameters('SQLManagedInstanceTLSDeployEffect')]"
@@ -565,7 +565,7 @@
       },
       {
         "policyDefinitionReferenceId": "SQLManagedInstanceTLSEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-SqlMi-minTLS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-SqlMi-minTLS",
         "parameters": {
           "effect": {
             "value": "[parameters('SQLManagedInstanceTLSEffect')]"
@@ -578,7 +578,7 @@
       },
       {
         "policyDefinitionReferenceId": "SQLServerTLSDeployEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-SQL-minTLS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-SQL-minTLS",
         "parameters": {
           "effect": {
             "value": "[parameters('SQLServerTLSDeployEffect')]"
@@ -591,7 +591,7 @@
       },
       {
         "policyDefinitionReferenceId": "SQLServerTLSEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Sql-minTLS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Sql-minTLS",
         "parameters": {
           "effect": {
             "value": "[parameters('SQLServerTLSEffect')]"
@@ -604,7 +604,7 @@
       },
       {
         "policyDefinitionReferenceId": "StorageHttpsEnabledEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Storage-minTLS",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Storage-minTLS",
         "parameters": {
           "effect": {
             "value": "[parameters('StorageHttpsEnabledEffect')]"
@@ -617,7 +617,7 @@
       },
       {
         "policyDefinitionReferenceId": "StorageDeployHttpsEnabledEffect",
-        "policyDefinitionId": "${current_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Storage-sslEnforcement",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Storage-sslEnforcement",
         "parameters": {
           "effect": {
             "value": "[parameters('StorageDeployHttpsEnabledEffect')]"

--- a/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_enforce_encrypttransit.tmpl.json
+++ b/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_enforce_encrypttransit.tmpl.json
@@ -490,7 +490,7 @@
       },
       {
         "policyDefinitionReferenceId": "PostgreSQLEnableSSLDeployEffect",
-        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSql-sslEnforcement",
+        "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-PostgreSQL-sslEnforcement",
         "parameters": {
           "effect": {
             "value": "[parameters('PostgreSQLEnableSSLDeployEffect')]"

--- a/modules/archetypes/locals.policy_definitions.tf
+++ b/modules/archetypes/locals.policy_definitions.tf
@@ -79,7 +79,7 @@ locals {
     {
       resource_id = "${local.provider_path.policy_definition}${policy}"
       scope_id    = local.scope_id
-      template    = local.archetype_policy_definitions_map[policy]
+      template    = try(local.archetype_policy_definitions_map[policy], null)
     }
   ]
 }

--- a/modules/archetypes/locals.policy_set_definitions.tf
+++ b/modules/archetypes/locals.policy_set_definitions.tf
@@ -79,7 +79,7 @@ locals {
     {
       resource_id = "${local.provider_path.policy_set_definition}${policy_set}"
       scope_id    = local.scope_id
-      template    = local.archetype_policy_set_definitions_map[policy_set]
+      template    = try(local.archetype_policy_set_definitions_map[policy_set], null)
     }
   ]
 }


### PR DESCRIPTION
This PR includes the following udpates and fixes:

- Updates the library templates to use `root_scope_resource_id` for policies deployed by this module
- Fix to remove incorrect Managed Identity from `Deploy-ASC-Monitoring` policy
- Fix to address missing Role Assignments for Policy Assignments using internal Policy Set Definitions
- Improve logic when processing Role Assignments for Policy Assignments with Managed Identities
- Initial work towards #51 where duplicate Policy Assignments at different scopes cause a duplicate key error
- Fix a bug where changing the `archetype_id` for an existing Management Group fails during the `plan` stage