### PR TITLE
Fix enforcement_mode and simplify try() logic

### DIFF
--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_appgw_without_waf.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_appgw_without_waf.tmpl.json
@@ -11,10 +11,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "None"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_appgw_without_waf.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_appgw_without_waf.tmpl.json
@@ -8,7 +8,8 @@
     "notScopes": [],
     "parameters": {},
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-AppGW-Without-WAF",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_http_ingress_aks.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_http_ingress_aks.tmpl.json
@@ -12,7 +12,8 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1a5b4dca-0b6f-4cf5-907c-56316bc1bf3d",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_http_ingress_aks.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_http_ingress_aks.tmpl.json
@@ -15,10 +15,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "None"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_ip_forwarding.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_ip_forwarding.tmpl.json
@@ -11,10 +11,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "None"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_ip_forwarding.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_ip_forwarding.tmpl.json
@@ -8,7 +8,8 @@
     "notScopes": [],
     "parameters": {},
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/88c0b9da-ce96-4b03-9635-f29a937e2900",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_priv_containers_aks.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_priv_containers_aks.tmpl.json
@@ -12,7 +12,8 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/95edb821-ddaf-4404-9732-666045e056b4",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_priv_containers_aks.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_priv_containers_aks.tmpl.json
@@ -15,10 +15,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "None"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_priv_escalation_aks.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_priv_escalation_aks.tmpl.json
@@ -12,7 +12,8 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/1c6e92c9-99f0-4e55-9cf2-0c234dc48f99",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_priv_escalation_aks.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_priv_escalation_aks.tmpl.json
@@ -15,10 +15,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "None"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_rdp_from_internet.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_rdp_from_internet.tmpl.json
@@ -11,10 +11,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "None"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_rdp_from_internet.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_rdp_from_internet.tmpl.json
@@ -8,7 +8,8 @@
     "notScopes": [],
     "parameters": {},
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-RDP-From-Internet",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_resource_locations.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_resource_locations.tmpl.json
@@ -18,10 +18,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "None"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_resource_locations.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_resource_locations.tmpl.json
@@ -15,7 +15,8 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e56962a6-4747-49cd-b67b-bf8b01975c4c",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_resource_types.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_resource_types.tmpl.json
@@ -14,7 +14,8 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/6c112d4e-5bc7-47ae-a041-ea2d9dccd749",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_resource_types.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_resource_types.tmpl.json
@@ -17,10 +17,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "None"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_rsg_locations.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_rsg_locations.tmpl.json
@@ -18,10 +18,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "None"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_rsg_locations.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_rsg_locations.tmpl.json
@@ -15,7 +15,8 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/e765b5de-1225-4ba3-bd56-1ac6695af988",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_storage_http.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_storage_http.tmpl.json
@@ -11,10 +11,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "None"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_storage_http.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_storage_http.tmpl.json
@@ -8,7 +8,8 @@
     "notScopes": [],
     "parameters": {},
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/404c3081-a854-4457-ae30-26a93ef643f9",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_subnet_without_nsg.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_subnet_without_nsg.tmpl.json
@@ -11,10 +11,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "None"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_subnet_without_nsg.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_subnet_without_nsg.tmpl.json
@@ -8,7 +8,8 @@
     "notScopes": [],
     "parameters": {},
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Subnet-Without-Nsg",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_subnet_without_udr.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_subnet_without_udr.tmpl.json
@@ -11,10 +11,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "None"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_subnet_without_udr.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_subnet_without_udr.tmpl.json
@@ -8,7 +8,8 @@
     "notScopes": [],
     "parameters": {},
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Subnet-Without-Udr",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_aks_policy.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_aks_policy.tmpl.json
@@ -8,7 +8,8 @@
     "notScopes": [],
     "parameters": {},
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a8eff44f-8c92-45c3-a3fb-9880802d67a7",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_aks_policy.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_aks_policy.tmpl.json
@@ -11,10 +11,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "SystemAssigned"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_asc_defender.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_asc_defender.tmpl.json
@@ -8,7 +8,8 @@
     "notScopes": [],
     "parameters": {},
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-ASC-Standard",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_asc_defender.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_asc_defender.tmpl.json
@@ -11,10 +11,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "SystemAssigned"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_asc_monitoring.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_asc_monitoring.tmpl.json
@@ -75,7 +75,8 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_asc_monitoring.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_asc_monitoring.tmpl.json
@@ -78,10 +78,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "None"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_azactivity_log.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_azactivity_log.tmpl.json
@@ -15,10 +15,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "SystemAssigned"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_azactivity_log.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_azactivity_log.tmpl.json
@@ -12,7 +12,8 @@
       }
     },
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Diagnostics-ActivityLog",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_log_analytics.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_log_analytics.tmpl.json
@@ -33,10 +33,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "SystemAssigned"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_log_analytics.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_log_analytics.tmpl.json
@@ -30,7 +30,8 @@
       }
     },
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deploy-Log-Analytics",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_lx_arc_monitoring.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_lx_arc_monitoring.tmpl.json
@@ -12,7 +12,8 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/9d2b61b4-1d14-4a63-be30-d4498e7ad2cf",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_lx_arc_monitoring.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_lx_arc_monitoring.tmpl.json
@@ -15,10 +15,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "SystemAssigned"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_resource_diag.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_resource_diag.tmpl.json
@@ -15,10 +15,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "SystemAssigned"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_resource_diag.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_resource_diag.tmpl.json
@@ -12,7 +12,8 @@
       }
     },
     "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policySetDefinitions/Deploy-Diag-LogAnalytics",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_sql_db_auditing.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_sql_db_auditing.tmpl.json
@@ -11,10 +11,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "SystemAssigned"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_sql_db_auditing.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_sql_db_auditing.tmpl.json
@@ -8,7 +8,8 @@
     "notScopes": [],
     "parameters": {},
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/a6fb4358-5bf4-4ad7-ba82-2cd2f41ce5e9",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_sql_security.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_sql_security.tmpl.json
@@ -8,7 +8,8 @@
     "notScopes": [],
     "parameters": {},
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/86a912f6-9a06-4e26-b447-11b16ba8659f",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_sql_security.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_sql_security.tmpl.json
@@ -11,10 +11,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "SystemAssigned"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_vm_backup.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_vm_backup.tmpl.json
@@ -8,7 +8,8 @@
     "notScopes": [],
     "parameters": {},
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/98d0b9f8-fd90-49c9-88e2-d3baf3b0dd86",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_vm_backup.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_vm_backup.tmpl.json
@@ -11,10 +11,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "SystemAssigned"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_vm_monitoring.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_vm_monitoring.tmpl.json
@@ -15,10 +15,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "SystemAssigned"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_vm_monitoring.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_vm_monitoring.tmpl.json
@@ -12,7 +12,8 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/55f3eceb-5573-4f18-9695-226972c6d74a",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_vmss_monitoring.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_vmss_monitoring.tmpl.json
@@ -15,10 +15,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "SystemAssigned"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_vmss_monitoring.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_vmss_monitoring.tmpl.json
@@ -12,7 +12,8 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/75714362-cae7-409e-9b99-a8e5075b7fad",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_ws_arc_monitoring.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_ws_arc_monitoring.tmpl.json
@@ -15,10 +15,6 @@
     "scope": "${current_scope_resource_id}",
     "enforcementMode": "Default"
   },
-  "sku": {
-    "name": "A0",
-    "tier": "Free"
-  },
   "location": "${default_location}",
   "identity": {
     "type": "SystemAssigned"

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_ws_arc_monitoring.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_ws_arc_monitoring.tmpl.json
@@ -12,7 +12,8 @@
       }
     },
     "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/69af7d4a-7b18-4044-93a9-2651498ef203",
-    "scope": "${current_scope_resource_id}"
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
   },
   "sku": {
     "name": "A0",

--- a/resources.policy_assignments.tf
+++ b/resources.policy_assignments.tf
@@ -18,7 +18,7 @@ resource "azurerm_policy_assignment" "enterprise_scale" {
   metadata         = try(length(each.value.template.properties.metadata) > 0, false) ? jsonencode(each.value.template.properties.metadata) : local.empty_string
   parameters       = try(length(each.value.template.properties.parameters) > 0, false) ? jsonencode(merge(each.value.template.properties.parameters, each.value.parameters)) : jsonencode(each.value.parameters)
   not_scopes       = try(length(each.value.template.properties.notScopes) > 0, false) ? each.value.template.properties.notScopes : local.empty_list
-  enforcement_mode = try(length(each.value.template.properties.enforcementMode) > 0, false) ? each.value.template.properties.enforcementMode : true
+  enforcement_mode = try(lower(each.value.template.properties.enforcementMode) == "default", true) ? true : false
 
   # Set explicit dependency on Management Group, Policy Definition and Policy Set Definition deployments
   depends_on = [

--- a/resources.policy_assignments.tf
+++ b/resources.policy_assignments.tf
@@ -9,15 +9,15 @@ resource "azurerm_policy_assignment" "enterprise_scale" {
 
   # Optional resource attributes
   identity {
-    type = try(length(each.value.template.identity.type) > 0, false) ? each.value.template.identity.type : "None"
+    type = try(each.value.template.identity.type, "None")
   }
 
-  location         = try(length(each.value.template.location) > 0, false) ? each.value.template.location : null
-  description      = try(length(each.value.template.properties.description) > 0, false) ? each.value.template.properties.description : "${each.value.template.name} Policy Assignment at scope ${each.value.scope_id}"
-  display_name     = try(length(each.value.template.properties.displayName) > 0, false) ? each.value.template.properties.displayName : each.value.template.name
-  metadata         = try(length(each.value.template.properties.metadata) > 0, false) ? jsonencode(each.value.template.properties.metadata) : local.empty_string
+  location         = try(each.value.template.location, null)
+  description      = try(each.value.template.properties.description, "${each.value.template.name} Policy Assignment at scope ${each.value.scope_id}")
+  display_name     = try(each.value.template.properties.displayName, each.value.template.name)
+  metadata         = try(length(each.value.template.properties.metadata) > 0, false) ? jsonencode(each.value.template.properties.metadata) : null
   parameters       = try(length(each.value.template.properties.parameters) > 0, false) ? jsonencode(merge(each.value.template.properties.parameters, each.value.parameters)) : jsonencode(each.value.parameters)
-  not_scopes       = try(length(each.value.template.properties.notScopes) > 0, false) ? each.value.template.properties.notScopes : local.empty_list
+  not_scopes       = try(each.value.template.properties.notScopes, local.empty_list)
   enforcement_mode = try(lower(each.value.template.properties.enforcementMode) == "default", true) ? true : false
 
   # Set explicit dependency on Management Group, Policy Definition and Policy Set Definition deployments

--- a/resources.policy_definitions.tf
+++ b/resources.policy_definitions.tf
@@ -8,11 +8,11 @@ resource "azurerm_policy_definition" "enterprise_scale" {
   display_name = each.value.template.properties.displayName
 
   # Optional resource attributes
-  description           = try(length(each.value.template.properties.description) > 0, false) ? each.value.template.properties.description : "${each.value.template.properties.displayName} Policy Definition at scope ${each.value.scope_id}"
-  management_group_name = try(length(each.value.scope_id) > 0, false) ? basename(each.value.scope_id) : null
-  policy_rule           = try(length(each.value.template.properties.policyRule) > 0, false) ? jsonencode(each.value.template.properties.policyRule) : local.empty_string
-  metadata              = try(length(each.value.template.properties.metadata) > 0, false) ? jsonencode(each.value.template.properties.metadata) : local.empty_string
-  parameters            = try(length(each.value.template.properties.parameters) > 0, false) ? jsonencode(each.value.template.properties.parameters) : local.empty_string
+  description           = try(each.value.template.properties.description, "${each.value.template.name} Policy Definition at scope ${each.value.scope_id}")
+  management_group_name = try(basename(each.value.scope_id), null)
+  policy_rule           = try(length(each.value.template.properties.policyRule) > 0, false) ? jsonencode(each.value.template.properties.policyRule) : null
+  metadata              = try(length(each.value.template.properties.metadata) > 0, false) ? jsonencode(each.value.template.properties.metadata) : null
+  parameters            = try(length(each.value.template.properties.parameters) > 0, false) ? jsonencode(each.value.template.properties.parameters) : null
 
   # Set explicit dependency on Management Group deployments
   depends_on = [

--- a/resources.policy_set_definitions.tf
+++ b/resources.policy_set_definitions.tf
@@ -12,23 +12,22 @@ resource "azurerm_policy_set_definition" "enterprise_scale" {
       for item in each.value.template.properties.policyDefinitions :
       {
         policyDefinitionId          = item.policyDefinitionId
-        parameters                  = item.parameters
-        policyDefinitionReferenceId = item.policyDefinitionReferenceId
+        parameters                  = try(jsonencode(item.parameters), null)
+        policyDefinitionReferenceId = try(item.policyDefinitionReferenceId, null)
       }
-      if try(length(each.value.template.properties.policyDefinitions) > 0, false)
     ]
     content {
       policy_definition_id = policy_definition_reference.value["policyDefinitionId"]
-      parameter_values     = try(length(policy_definition_reference.value["parameters"]) > 0, false) ? jsonencode(policy_definition_reference.value["parameters"]) : null
-      reference_id         = try(length(policy_definition_reference.value["policyDefinitionReferenceId"]) > 0, false) ? policy_definition_reference.value["policyDefinitionReferenceId"] : policy_definition_reference.value["policyDefinitionId"]
+      parameter_values     = policy_definition_reference.value["parameters"]
+      reference_id         = policy_definition_reference.value["policyDefinitionReferenceId"]
     }
   }
 
   # Optional resource attributes
-  description           = try(length(each.value.template.properties.description) > 0, false) ? each.value.template.properties.description : "${each.value.template.properties.displayName} Policy Set Definition at scope ${each.value.scope_id}"
-  management_group_name = try(length(each.value.scope_id) > 0, false) ? basename(each.value.scope_id) : null
-  metadata              = try(length(each.value.template.properties.metadata) > 0, false) ? jsonencode(each.value.template.properties.metadata) : local.empty_string
-  parameters            = try(length(each.value.template.properties.parameters) > 0, false) ? jsonencode(each.value.template.properties.parameters) : local.empty_string
+  description           = try(each.value.template.properties.description, "${each.value.template.properties.displayName} Policy Set Definition at scope ${each.value.scope_id}")
+  management_group_name = try(basename(each.value.scope_id), null)
+  metadata              = try(length(each.value.template.properties.metadata) > 0, false) ? jsonencode(each.value.template.properties.metadata) : null
+  parameters            = try(length(each.value.template.properties.parameters) > 0, false) ? jsonencode(each.value.template.properties.parameters) : null
 
   # Set explicit dependency on Management Group and Policy Definition deployments
   depends_on = [

--- a/resources.role_definitions.tf
+++ b/resources.role_definitions.tf
@@ -10,14 +10,14 @@ resource "azurerm_role_definition" "enterprise_scale" {
   scope = each.value.scope_id
 
   permissions {
-    actions          = try(length(each.value.template.properties.permissions[0].actions) > 0, false) ? each.value.template.properties.permissions[0].actions : local.empty_list
-    not_actions      = try(length(each.value.template.properties.permissions[0].notActions) > 0, false) ? each.value.template.properties.permissions[0].notActions : local.empty_list
-    data_actions     = try(length(each.value.template.properties.permissions[0].dataActions) > 0, false) ? each.value.template.properties.permissions[0].dataActions : local.empty_list
-    not_data_actions = try(length(each.value.template.properties.permissions[0].notDataActions) > 0, false) ? each.value.template.properties.permissions[0].notDataActions : local.empty_list
+    actions          = try(each.value.template.properties.permissions[0].actions, local.empty_list)
+    not_actions      = try(each.value.template.properties.permissions[0].notActions, local.empty_list)
+    data_actions     = try(each.value.template.properties.permissions[0].dataActions, local.empty_list)
+    not_data_actions = try(each.value.template.properties.permissions[0].notDataActions, local.empty_list)
   }
 
   # Optional resource attributes
-  description       = try(length(each.value.template.properties.description) > 0, false) ? each.value.template.properties.description : "${each.value.template.properties.roleName} Role Definition at scope ${each.value.scope_id}"
+  description       = try(each.value.template.properties.description, "${each.value.template.properties.roleName} Role Definition at scope ${each.value.scope_id}")
   assignable_scopes = try(length(each.value.template.properties.assignableScopes) > 0, false) ? each.value.template.properties.assignableScopes : [each.value.scope_id, ]
 
   # Set explicit dependency on Management Group deployments

--- a/tests/deployment/lib/policy_assignments/policy_assignment_test_policy_definition.json
+++ b/tests/deployment/lib/policy_assignments/policy_assignment_test_policy_definition.json
@@ -15,7 +15,8 @@
             }
         },
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/f4c68484-132f-41f9-9b6d-3e4b1cb55036",
-        "scope": "${current_scope_resource_id}"
+        "scope": "${current_scope_resource_id}",
+        "enforcementMode": "Default"
     },
     "location": "${default_location}",
     "identity": {

--- a/tests/deployment/lib/policy_assignments/policy_assignment_test_policy_set_definition.json
+++ b/tests/deployment/lib/policy_assignments/policy_assignment_test_policy_set_definition.json
@@ -21,7 +21,8 @@
             }
         },
         "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/a169a624-5599-4385-a696-c8d643089fab",
-        "scope": "${current_scope_resource_id}"
+        "scope": "${current_scope_resource_id}",
+        "enforcementMode": "Default"
     },
     "location": "${default_location}",
     "identity": {


### PR DESCRIPTION
This PR fixes the logic used to control the `enforcement_mode` configuration for Policy Assignments, and adds this setting to the Policy Assignments provided as part of this module.

It also removes the now obsolete `sku` argument from the Policy Assignments, and includes a number of changes to simplify the `try()` logic used to handle missing values for optional arguments on resources.