### PR TITLE
Update `retention_in_days` config to fix #99

### DIFF
--- a/modules/management/locals.tf
+++ b/modules/management/locals.tf
@@ -1,8 +1,6 @@
 # The following block of locals are used to avoid using
 # empty object types in the code.
 locals {
-  empty_list   = []
-  empty_map    = {}
   empty_string = ""
 }
 
@@ -101,7 +99,7 @@ locals {
     name                              = try(local.custom_settings_la_workspace.name, "${local.resource_prefix}-la${local.resource_suffix}")
     location                          = try(local.custom_settings_la_workspace.location, local.location)
     sku                               = try(local.custom_settings_la_workspace.sku, "PerGB2018")
-    retention_in_days                 = try(local.custom_settings_la_workspace.retention_in_days, 30)
+    retention_in_days                 = try(local.custom_settings_la_workspace.retention_in_days, local.settings.log_analytics.config.retention_in_days)
     daily_quota_gb                    = try(local.custom_settings_la_workspace.daily_quota_gb, null)
     internet_ingestion_enabled        = try(local.custom_settings_la_workspace.internet_ingestion_enabled, true)
     internet_query_enabled            = try(local.custom_settings_la_workspace.internet_query_enabled, true)

--- a/modules/management/outputs.tf
+++ b/modules/management/outputs.tf
@@ -1,4 +1,4 @@
 output "configuration" {
   value       = local.module_output
-  description = "Returns the resources to deploy for the management solution and additional configuration settings."
+  description = "Returns the configuration settings for resources to deploy for the management solution."
 }

--- a/modules/management/variables.tf
+++ b/modules/management/variables.tf
@@ -94,7 +94,7 @@ variable "resource_prefix" {
 
 variable "resource_suffix" {
   type        = string
-  description = "If specified, will set the resource name suffix for management resources (default value determined from \"var.subscription_id\")."
+  description = "If specified, will set the resource name suffix for management resources."
   default     = ""
 
   validation {


### PR DESCRIPTION
This PR introduces a change to the logic used to set the Log Analytics workspace setting for `retention_in_days` to fix issue #99 

> **NOTE:** This is not a breaking change, but will result in an update to customer environments where this value has been modified in code but incorrectly applied in Azure,