### PR TITLE
Add "Identity" module

### DIFF
--- a/locals.management_groups.tf
+++ b/locals.management_groups.tf
@@ -211,6 +211,7 @@ locals {
         access_control = value.archetype_config.access_control
         parameters = merge(
           value.archetype_config.parameters,
+          try(module.identity_resources.configuration.archetype_config_overrides[key].parameters, null),
           try(module.management_resources.configuration.archetype_config_overrides[key].parameters, null),
         )
       }

--- a/locals.tf
+++ b/locals.tf
@@ -15,7 +15,9 @@ locals {
   deploy_core_landing_zones      = var.deploy_core_landing_zones
   deploy_demo_landing_zones      = var.deploy_demo_landing_zones
   deploy_management_resources    = var.deploy_management_resources
+  deploy_identity_resources      = var.deploy_identity_resources
   configure_management_resources = var.configure_management_resources
+  configure_identity_resources   = var.configure_identity_resources
   archetype_config_overrides     = var.archetype_config_overrides
   subscription_id_overrides      = var.subscription_id_overrides
   subscription_id_connectivity   = var.subscription_id_connectivity

--- a/main.tf
+++ b/main.tf
@@ -44,3 +44,14 @@ module "management_resources" {
   link_log_analytics_to_automation_account     = try(local.configure_management_resources.advanced.link_log_analytics_to_automation_account, true)
   custom_settings_by_resource_type             = try(local.configure_management_resources.advanced.custom_settings_by_resource_type, local.empty_map)
 }
+
+# The following module is used to generate the configuration
+# data used to deploy platform resources based on the
+# "identity" landing zone archetype.
+module "identity_resources" {
+  source = "./modules/identity"
+
+  # Mandatory input variables 
+  enabled  = local.deploy_identity_resources
+  settings = local.configure_identity_resources.settings
+}

--- a/main.tf
+++ b/main.tf
@@ -12,11 +12,14 @@ module "management_group_archetypes" {
   scope_id                = each.key
   archetype_id            = each.value.archetype_config.archetype_id
   parameters              = each.value.archetype_config.parameters
-  enforcement_mode        = try(module.management_resources.configuration.archetype_config_overrides[basename(each.key)].enforcement_mode, null)
   access_control          = each.value.archetype_config.access_control
   library_path            = local.library_path
   template_file_variables = local.template_file_variables
   default_location        = local.default_location
+  enforcement_mode = merge(
+    try(module.identity_resources.configuration.archetype_config_overrides[basename(each.key)].enforcement_mode, null),
+    try(module.management_resources.configuration.archetype_config_overrides[basename(each.key)].enforcement_mode, null),
+  )
 }
 
 # The following module is used to generate the configuration
@@ -53,5 +56,6 @@ module "identity_resources" {
 
   # Mandatory input variables 
   enabled  = local.deploy_identity_resources
+  root_id  = local.root_id
   settings = local.configure_identity_resources.settings
 }

--- a/modules/archetypes/lib/archetype_definitions/archetype_definition_es_identity.tmpl.json
+++ b/modules/archetypes/lib/archetype_definitions/archetype_definition_es_identity.tmpl.json
@@ -1,6 +1,11 @@
 {
     "es_identity": {
-        "policy_assignments": [],
+        "policy_assignments": [
+            "Deny-Public-IP",
+            "Deny-RDP-From-Internet",
+            "Deny-Subnet-Without-Nsg",
+            "Deploy-VM-Backup"
+        ],
         "policy_definitions": [],
         "policy_set_definitions": [],
         "role_definitions": [],

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_public_ip.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_public_ip.tmpl.json
@@ -1,0 +1,18 @@
+{
+  "name": "Deny-Public-IP",
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2019-09-01",
+  "properties": {
+    "description": "This policy denies creation of Public IPs under the assigned scope.",
+    "displayName": "Deny the creation of public IP",
+    "notScopes": [],
+    "parameters": {},
+    "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-PublicIP",
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
+  },
+  "location": "${default_location}",
+  "identity": {
+    "type": "None"
+  }
+}

--- a/modules/identity/locals.tf
+++ b/modules/identity/locals.tf
@@ -5,6 +5,7 @@
 # no value for subscription_id is provided.
 locals {
   enabled  = var.enabled
+  root_id  = var.root_id
   settings = var.settings
 }
 

--- a/modules/identity/locals.tf
+++ b/modules/identity/locals.tf
@@ -1,0 +1,56 @@
+# Convert the input vars to locals, applying any required
+# logic needed before they are used in the module.
+# No vars should be referenced elsewhere in the module.
+# NOTE: Need to catch error for resource_suffix when
+# no value for subscription_id is provided.
+locals {
+  enabled  = var.enabled
+  settings = var.settings
+}
+
+# Logic to determine whether specific resources
+# should be created by this module
+locals {
+  deploy_identity                          = local.enabled && local.settings.identity.enabled
+  deploy_enable_deny_public_ip             = local.deploy_identity && local.settings.identity.config.enable_deny_public_ip
+  deploy_enable_deny_rdp_from_internet     = local.deploy_identity && local.settings.identity.config.enable_deny_rdp_from_internet
+  deploy_enable_deny_subnet_without_nsg    = local.deploy_identity && local.settings.identity.config.enable_deny_subnet_without_nsg
+  deploy_enable_deploy_azure_backup_on_vms = local.deploy_identity && local.settings.identity.config.enable_deploy_azure_backup_on_vms
+}
+
+# Archetype configuration overrides
+locals {
+  archetype_config_overrides = {
+    "${local.root_id}-identity" = {
+      parameters = {
+        Deny-Public-IP = {
+          effect = "Deny"
+        }
+        Deny-RDP-From-Internet = {
+          effect = "Deny"
+        }
+        Deny-Subnet-Without-Nsg = {
+          effect = "Deny"
+        }
+        Deploy-VM-Backup = {
+          effect            = "deployIfNotExists"
+          exclusionTagName  = ""
+          exclusionTagValue = []
+        }
+      }
+      enforcement_mode = {
+        Deny-Public-IP          = local.deploy_enable_deny_public_ip
+        Deny-RDP-From-Internet  = local.deploy_enable_deny_rdp_from_internet
+        Deny-Subnet-Without-Nsg = local.deploy_enable_deny_subnet_without_nsg
+        Deploy-VM-Backup        = local.deploy_enable_deploy_azure_backup_on_vms
+      }
+    }
+  }
+}
+
+# Generate the configuration output object for the module
+locals {
+  module_output = {
+    archetype_config_overrides = local.archetype_config_overrides
+  }
+}

--- a/modules/identity/main.tf
+++ b/modules/identity/main.tf
@@ -1,0 +1,2 @@
+# No resources deployed by this module so this file is here as an entry point only
+# Please navigate the variables, locals and outputs to see how the data model is generated from the inputs

--- a/modules/identity/outputs.tf
+++ b/modules/identity/outputs.tf
@@ -1,0 +1,4 @@
+output "configuration" {
+  value       = local.module_output
+  description = "Returns the configuration settings for resources to deploy for the identity solution."
+}

--- a/modules/identity/variables.tf
+++ b/modules/identity/variables.tf
@@ -1,0 +1,25 @@
+# The following variables are used to determine the archetype
+# definition to use and create the required resources.
+#
+# Further information provided within the description block
+# for each variable
+
+variable "enabled" {
+  type        = bool
+  description = "Controls whether to manage the identity landing zone policies and deploy the identity resources into the current Subscription context."
+}
+
+variable "settings" {
+  type = object({
+    identity = object({
+      enabled = bool
+      config = object({
+        enable_deny_rdp_from_internet     = bool
+        enable_deny_public_ip             = bool
+        enable_deploy_azure_backup_on_vms = bool
+        enable_deny_subnet_without_nsg    = bool
+      })
+    })
+  })
+  description = "Configuration settings for the \"Identity\" landing zone resources."
+}

--- a/modules/identity/variables.tf
+++ b/modules/identity/variables.tf
@@ -9,6 +9,16 @@ variable "enabled" {
   description = "Controls whether to manage the identity landing zone policies and deploy the identity resources into the current Subscription context."
 }
 
+variable "root_id" {
+  type        = string
+  description = "Specifies the ID of the Enterprise-scale root Management Group, used as a prefix for resources created by this module."
+
+  validation {
+    condition     = can(regex("^[a-zA-Z0-9-]{2,10}$", var.root_id))
+    error_message = "Value must be between 2 to 10 characters long, consisting of alphanumeric characters and hyphens."
+  }
+}
+
 variable "settings" {
   type = object({
     identity = object({

--- a/modules/identity/variables.tf
+++ b/modules/identity/variables.tf
@@ -14,10 +14,10 @@ variable "settings" {
     identity = object({
       enabled = bool
       config = object({
-        enable_deny_rdp_from_internet     = bool
         enable_deny_public_ip             = bool
-        enable_deploy_azure_backup_on_vms = bool
+        enable_deny_rdp_from_internet     = bool
         enable_deny_subnet_without_nsg    = bool
+        enable_deploy_azure_backup_on_vms = bool
       })
     })
   })

--- a/modules/management/variables.tf
+++ b/modules/management/variables.tf
@@ -6,7 +6,7 @@
 
 variable "enabled" {
   type        = bool
-  description = "Controls whether to deploy the management resources into the current Subscription context."
+  description = "Controls whether to manage the management landing zone policies and deploy the management resources into the current Subscription context."
 }
 
 variable "root_id" {

--- a/variables.tf
+++ b/variables.tf
@@ -50,7 +50,7 @@ variable "deploy_demo_landing_zones" {
 
 variable "deploy_management_resources" {
   type        = bool
-  description = "If set to true, will deploy the \"Management\" landing zone resources into the current Subscription context."
+  description = "If set to true, will deploy the \"Management\" landing zone settings and add resources into the current Subscription context."
   default     = false
 }
 
@@ -96,7 +96,7 @@ variable "configure_management_resources" {
     tags     = any
     advanced = any
   })
-  description = "If specified, will customize the \"Management\" landing zone resources."
+  description = "If specified, will customize the \"Management\" landing zone settings and resources."
   default = {
     settings = {
       log_analytics = {
@@ -137,6 +137,42 @@ variable "configure_management_resources" {
     location = null
     tags     = null
     advanced = null
+  }
+}
+
+variable "deploy_identity_resources" {
+  type        = bool
+  description = "If set to true, will deploy the \"Identity\" landing zone settings."
+  default     = false
+}
+
+variable "configure_identity_resources" {
+  type = object({
+    settings = object({
+      identity = object({
+        enabled = bool
+        config = object({
+          enable_deny_public_ip             = bool
+          enable_deny_rdp_from_internet     = bool
+          enable_deny_subnet_without_nsg    = bool
+          enable_deploy_azure_backup_on_vms = bool
+        })
+      })
+    })
+  })
+  description = "If specified, will customize the \"Identity\" landing zone settings."
+  default = {
+    settings = {
+      identity = {
+        enabled = true
+        config = {
+          enable_deny_public_ip             = true
+          enable_deny_rdp_from_internet     = true
+          enable_deny_subnet_without_nsg    = true
+          enable_deploy_azure_backup_on_vms = true
+        }
+      }
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds the following features:

- Add the following new `Policy Assignments` at the `Identity` landing zones scope:
  - "Deny-Public-IP"
  - "Deny-RDP-From-Internet"
  - "Deny-Subnet-Without-Nsg"
  - "Deploy-VM-Backup"
- Integration with a new `Identity` child module, providing managed settings for both `parameters` and `enforcement_mode` on these `Policy Assignments`.
- Added the following new input `variables` to the module to enable configuration of the new `Identity` child module:
  - `deploy_identity_resources`
  - `configure_identity_resources`

> No breaking changes are included in this PR, but new resources will be created by the module