### PR TITLE
Improvements to management logic

### DIFF
--- a/locals.management_groups.tf
+++ b/locals.management_groups.tf
@@ -147,20 +147,29 @@ locals {
     "${local.root_id}-connectivity" = {
       display_name               = "Connectivity"
       parent_management_group_id = "${local.root_id}-platform"
-      subscription_ids           = local.es_subscription_ids_map["${local.root_id}-connectivity"]
-      archetype_config           = local.es_archetype_config_map["${local.root_id}-connectivity"]
+      subscription_ids = distinct(compact(concat(
+        [local.subscription_id_connectivity],
+        local.es_subscription_ids_map["${local.root_id}-connectivity"],
+      )))
+      archetype_config = local.es_archetype_config_map["${local.root_id}-connectivity"]
     }
     "${local.root_id}-management" = {
       display_name               = "Management"
       parent_management_group_id = "${local.root_id}-platform"
-      subscription_ids           = local.es_subscription_ids_map["${local.root_id}-management"]
-      archetype_config           = local.es_archetype_config_map["${local.root_id}-management"]
+      subscription_ids = distinct(compact(concat(
+        [local.subscription_id_management],
+        local.es_subscription_ids_map["${local.root_id}-management"],
+      )))
+      archetype_config = local.es_archetype_config_map["${local.root_id}-management"]
     }
     "${local.root_id}-identity" = {
       display_name               = "Identity"
       parent_management_group_id = "${local.root_id}-platform"
-      subscription_ids           = local.es_subscription_ids_map["${local.root_id}-identity"]
-      archetype_config           = local.es_archetype_config_map["${local.root_id}-identity"]
+      subscription_ids = distinct(compact(concat(
+        [local.subscription_id_identity],
+        local.es_subscription_ids_map["${local.root_id}-identity"],
+      )))
+      archetype_config = local.es_archetype_config_map["${local.root_id}-identity"]
     }
   }
   # Optional demo "Landing Zone" Enterprise-scale Management Groups

--- a/modules/management/locals.tf
+++ b/modules/management/locals.tf
@@ -38,27 +38,28 @@ locals {
 # Logic to determine whether specific resources
 # should be created by this module
 locals {
-  deploy_monitoring                   = local.enabled && local.settings.log_analytics.enabled
-  deploy_monitoring_for_arc           = local.deploy_monitoring && local.settings.log_analytics.config.enable_monitoring_for_arc
-  deploy_monitoring_for_vm            = local.deploy_monitoring && local.settings.log_analytics.config.enable_monitoring_for_vm
-  deploy_monitoring_for_vmss          = local.deploy_monitoring && local.settings.log_analytics.config.enable_monitoring_for_vmss
-  deploy_resource_group               = local.deploy_monitoring && local.existing_resource_group_name == local.empty_string
-  deploy_log_analytics_workspace      = local.deploy_monitoring && local.existing_log_analytics_workspace_resource_id == local.empty_string
-  deploy_log_analytics_linked_service = local.deploy_monitoring && local.link_log_analytics_to_automation_account
-  deploy_automation_account           = local.deploy_monitoring && local.existing_automation_account_resource_id == local.empty_string
+  deploy_monitoring_settings          = local.settings.log_analytics.enabled
+  deploy_monitoring_for_arc           = local.deploy_monitoring_settings && local.settings.log_analytics.config.enable_monitoring_for_arc
+  deploy_monitoring_for_vm            = local.deploy_monitoring_settings && local.settings.log_analytics.config.enable_monitoring_for_vm
+  deploy_monitoring_for_vmss          = local.deploy_monitoring_settings && local.settings.log_analytics.config.enable_monitoring_for_vmss
+  deploy_monitoring_resources         = local.enabled && local.deploy_monitoring_settings
+  deploy_resource_group               = local.deploy_monitoring_resources && local.existing_resource_group_name == local.empty_string
+  deploy_log_analytics_workspace      = local.deploy_monitoring_resources && local.existing_log_analytics_workspace_resource_id == local.empty_string
+  deploy_log_analytics_linked_service = local.deploy_monitoring_resources && local.link_log_analytics_to_automation_account
+  deploy_automation_account           = local.deploy_monitoring_resources && local.existing_automation_account_resource_id == local.empty_string
   deploy_azure_monitor_solutions = {
-    AgentHealthAssessment = local.deploy_monitoring && local.settings.log_analytics.config.enable_solution_for_agent_health_assessment
-    AntiMalware           = local.deploy_monitoring && local.settings.log_analytics.config.enable_solution_for_anti_malware
-    AzureActivity         = local.deploy_monitoring && local.settings.log_analytics.config.enable_solution_for_azure_activity
-    ChangeTracking        = local.deploy_monitoring && local.settings.log_analytics.config.enable_solution_for_change_tracking
-    Security              = local.deploy_monitoring && local.settings.log_analytics.config.enable_sentinel
-    SecurityInsights      = local.deploy_monitoring && local.settings.log_analytics.config.enable_sentinel
-    ServiceMap            = local.deploy_monitoring && local.settings.log_analytics.config.enable_solution_for_service_map
-    SQLAssessment         = local.deploy_monitoring && local.settings.log_analytics.config.enable_solution_for_sql_assessment
-    Updates               = local.deploy_monitoring && local.settings.log_analytics.config.enable_solution_for_updates
-    VMInsights            = local.deploy_monitoring && local.settings.log_analytics.config.enable_solution_for_vm_insights
+    AgentHealthAssessment = local.deploy_monitoring_resources && local.settings.log_analytics.config.enable_solution_for_agent_health_assessment
+    AntiMalware           = local.deploy_monitoring_resources && local.settings.log_analytics.config.enable_solution_for_anti_malware
+    AzureActivity         = local.deploy_monitoring_resources && local.settings.log_analytics.config.enable_solution_for_azure_activity
+    ChangeTracking        = local.deploy_monitoring_resources && local.settings.log_analytics.config.enable_solution_for_change_tracking
+    Security              = local.deploy_monitoring_resources && local.settings.log_analytics.config.enable_sentinel
+    SecurityInsights      = local.deploy_monitoring_resources && local.settings.log_analytics.config.enable_sentinel
+    ServiceMap            = local.deploy_monitoring_resources && local.settings.log_analytics.config.enable_solution_for_service_map
+    SQLAssessment         = local.deploy_monitoring_resources && local.settings.log_analytics.config.enable_solution_for_sql_assessment
+    Updates               = local.deploy_monitoring_resources && local.settings.log_analytics.config.enable_solution_for_updates
+    VMInsights            = local.deploy_monitoring_resources && local.settings.log_analytics.config.enable_solution_for_vm_insights
   }
-  deploy_security                    = local.enabled && local.settings.security_center.enabled
+  deploy_security_settings           = local.settings.security_center.enabled
   deploy_defender_for_acr            = local.settings.security_center.config.enable_defender_for_acr
   deploy_defender_for_app_services   = local.settings.security_center.config.enable_defender_for_app_services
   deploy_defender_for_arm            = local.settings.security_center.config.enable_defender_for_arm
@@ -218,7 +219,7 @@ locals {
         }
       }
       enforcement_mode = {
-        Deploy-ASC-Defender      = local.deploy_security
+        Deploy-ASC-Defender      = local.deploy_security_settings
         Deploy-LX-Arc-Monitoring = local.deploy_monitoring_for_arc
         Deploy-VM-Monitoring     = local.deploy_monitoring_for_vm
         Deploy-VMSS-Monitoring   = local.deploy_monitoring_for_vmss
@@ -237,7 +238,7 @@ locals {
         }
       }
       enforcement_mode = {
-        Deploy-Log-Analytics = local.deploy_monitoring
+        Deploy-Log-Analytics = local.deploy_monitoring_settings
       }
     }
   }

--- a/tests/deployment/locals.core.tf
+++ b/tests/deployment/locals.core.tf
@@ -1,0 +1,194 @@
+# Configure the custom landing zones to deploy in
+# addition the core resource hierarchy.
+locals {
+  custom_landing_zones = {
+    "${var.root_id_3}-customer-corp" = {
+      display_name               = "Corp Custom"
+      parent_management_group_id = "${var.root_id_3}-landing-zones"
+      subscription_ids           = []
+      archetype_config = {
+        archetype_id   = "default_empty"
+        parameters     = {}
+        access_control = {}
+      }
+    }
+    "${var.root_id_3}-customer-sap" = {
+      display_name               = "SAP"
+      parent_management_group_id = "${var.root_id_3}-landing-zones"
+      subscription_ids           = []
+      archetype_config = {
+        archetype_id = "customer_secure"
+        parameters = {
+          Deny-Resource-Locations = {
+            listOfAllowedLocations = [
+              "eastus",
+              "westus",
+            ]
+          }
+          Deny-RSG-Locations = {
+            listOfAllowedLocations = [
+              "eastus",
+              "westus",
+            ]
+          }
+          Deploy-HITRUST-HIPAA = {
+            CertificateThumbprints                                        = ""
+            DeployDiagnosticSettingsforNetworkSecurityGroupsrgName        = "${var.root_id_3}-rg"
+            DeployDiagnosticSettingsforNetworkSecurityGroupsstoragePrefix = var.root_id_3
+            installedApplicationsOnWindowsVM                              = ""
+            listOfLocations = [
+              "eastus",
+            ]
+          }
+        }
+        access_control = {}
+      }
+    }
+    "${var.root_id_3}-customer-online" = {
+      display_name               = "Online"
+      parent_management_group_id = "${var.root_id_3}-landing-zones"
+      subscription_ids           = []
+      archetype_config = {
+        archetype_id = "customer_online"
+        parameters = {
+          Deny-Resource-Locations = {
+            listOfAllowedLocations = [
+              "eastus",
+              "westus",
+              "uksouth",
+              "ukwest",
+            ]
+          }
+          Deny-RSG-Locations = {
+            listOfAllowedLocations = [
+              "eastus",
+              "westus",
+              "uksouth",
+              "ukwest",
+            ]
+          }
+        }
+        access_control = {}
+      }
+    }
+    "${var.root_id_3}-customer-web-prod" = {
+      display_name               = "Prod Web Applications"
+      parent_management_group_id = "${var.root_id_3}-customer-online"
+      subscription_ids           = []
+      archetype_config = {
+        archetype_id   = "default_empty"
+        parameters     = {}
+        access_control = {}
+      }
+    }
+    "${var.root_id_3}-customer-web-test" = {
+      display_name               = "Test Web Applications"
+      parent_management_group_id = "${var.root_id_3}-customer-online"
+      subscription_ids           = []
+      archetype_config = {
+        archetype_id = "customer_online"
+        parameters = {
+          Deny-Resource-Locations = {
+            listOfAllowedLocations = [
+              "eastus",
+              "westus",
+            ]
+          }
+          Deny-RSG-Locations = {
+            listOfAllowedLocations = [
+              "eastus",
+              "westus",
+            ]
+          }
+        }
+        access_control = {}
+      }
+    }
+    "${var.root_id_3}-customer-web-dev" = {
+      display_name               = "Dev Web Applications"
+      parent_management_group_id = "${var.root_id_3}-customer-online"
+      subscription_ids           = []
+      archetype_config = {
+        archetype_id = "customer_online"
+        parameters = {
+          Deny-Resource-Locations = {
+            listOfAllowedLocations = [
+              "eastus",
+            ]
+          }
+          Deny-RSG-Locations = {
+            listOfAllowedLocations = [
+              "eastus",
+            ]
+          }
+        }
+        access_control = {}
+      }
+    }
+
+  }
+}
+
+# Configure the archetype config overrides to customize
+# the configuration.
+locals {
+  archetype_config_overrides = {
+    root = {
+      archetype_id = "es_root"
+      parameters = {
+        Deny-Resource-Locations = {
+          listOfAllowedLocations = [
+            "eastus",
+            "eastus2",
+            "westus",
+            "northcentralus",
+            "southcentralus",
+            "uksouth",
+            "ukwest",
+          ]
+        }
+        Deny-RSG-Locations = {
+          listOfAllowedLocations = [
+            "eastus",
+            "eastus2",
+            "westus",
+            "northcentralus",
+            "southcentralus",
+            "uksouth",
+            "ukwest",
+          ]
+        }
+        Deploy-HITRUST-HIPAA = {
+          CertificateThumbprints                                        = ""
+          DeployDiagnosticSettingsforNetworkSecurityGroupsrgName        = "${var.root_id_3}-rg"
+          DeployDiagnosticSettingsforNetworkSecurityGroupsstoragePrefix = var.root_id_3
+          installedApplicationsOnWindowsVM                              = ""
+          listOfLocations = [
+            "eastus",
+          ]
+        }
+      }
+      access_control = {}
+    }
+  }
+}
+
+# Configure the Subscription ID overrides to ensure
+# Subscriptions are moved into the target management
+# group.
+locals {
+  subscription_id_overrides = {
+    root           = []
+    decommissioned = []
+    sandboxes      = []
+    landing-zones  = []
+    platform       = []
+    connectivity   = []
+    management     = []
+    identity       = []
+    demo-corp      = []
+    demo-online    = []
+    demo-sap       = []
+  }
+
+}

--- a/tests/deployment/locals.management.tf
+++ b/tests/deployment/locals.management.tf
@@ -1,0 +1,47 @@
+# Configure the management resources settings.
+locals {
+  configure_management_resources = {
+    settings = {
+      log_analytics = {
+        enabled = true
+        config = {
+          retention_in_days                           = 60
+          enable_monitoring_for_arc                   = false
+          enable_monitoring_for_vm                    = true
+          enable_monitoring_for_vmss                  = true
+          enable_solution_for_agent_health_assessment = true
+          enable_solution_for_anti_malware            = false
+          enable_solution_for_azure_activity          = true
+          enable_solution_for_change_tracking         = true
+          enable_solution_for_service_map             = true
+          enable_solution_for_sql_assessment          = false
+          enable_solution_for_updates                 = true
+          enable_solution_for_vm_insights             = true
+          enable_sentinel                             = false
+        }
+      }
+      security_center = {
+        enabled = true
+        config = {
+          email_security_contact             = "test.user@replace_me"
+          enable_defender_for_acr            = true
+          enable_defender_for_app_services   = true
+          enable_defender_for_arm            = true
+          enable_defender_for_dns            = true
+          enable_defender_for_key_vault      = true
+          enable_defender_for_kubernetes     = true
+          enable_defender_for_servers        = true
+          enable_defender_for_sql_servers    = true
+          enable_defender_for_sql_server_vms = true
+          enable_defender_for_storage        = true
+        }
+      }
+    }
+
+    location = null
+    tags = {
+      deployedBy = "terraform/azure/caf-enterprise-scale"
+    }
+    advanced = null
+  }
+}

--- a/tests/deployment/main.tf
+++ b/tests/deployment/main.tf
@@ -23,191 +23,22 @@ module "test_root_id_2" {
 module "test_root_id_3" {
   source = "../../"
 
-  root_parent_id = data.azurerm_client_config.current.tenant_id
-  root_id        = var.root_id_3
-  root_name      = "${var.root_name}-3"
-  library_path   = "${path.root}/lib"
+  # Base module configuration settings
+  root_parent_id   = data.azurerm_client_config.current.tenant_id
+  root_id          = var.root_id_3
+  root_name        = "${var.root_name}-3"
+  library_path     = "${path.root}/lib"
+  default_location = var.location
 
-  custom_landing_zones = {
-    "${var.root_id_3}-customer-corp" = {
-      display_name               = "Corp Custom"
-      parent_management_group_id = "${var.root_id_3}-landing-zones"
-      subscription_ids           = []
-      archetype_config = {
-        archetype_id   = "default_empty"
-        parameters     = {}
-        access_control = {}
-      }
-    }
-    "${var.root_id_3}-customer-sap" = {
-      display_name               = "SAP"
-      parent_management_group_id = "${var.root_id_3}-landing-zones"
-      subscription_ids           = []
-      archetype_config = {
-        archetype_id = "customer_secure"
-        parameters = {
-          Deny-Resource-Locations = {
-            listOfAllowedLocations = [
-              "eastus",
-              "westus",
-            ]
-          }
-          Deny-RSG-Locations = {
-            listOfAllowedLocations = [
-              "eastus",
-              "westus",
-            ]
-          }
-          Deploy-HITRUST-HIPAA = {
-            CertificateThumbprints                                        = ""
-            DeployDiagnosticSettingsforNetworkSecurityGroupsrgName        = "${var.root_id_3}-rg"
-            DeployDiagnosticSettingsforNetworkSecurityGroupsstoragePrefix = var.root_id_3
-            installedApplicationsOnWindowsVM                              = ""
-            listOfLocations = [
-              "eastus",
-            ]
-          }
-        }
-        access_control = {}
-      }
-    }
-    "${var.root_id_3}-customer-online" = {
-      display_name               = "Online"
-      parent_management_group_id = "${var.root_id_3}-landing-zones"
-      subscription_ids           = []
-      archetype_config = {
-        archetype_id = "customer_online"
-        parameters = {
-          Deny-Resource-Locations = {
-            listOfAllowedLocations = [
-              "eastus",
-              "westus",
-              "uksouth",
-              "ukwest",
-            ]
-          }
-          Deny-RSG-Locations = {
-            listOfAllowedLocations = [
-              "eastus",
-              "westus",
-              "uksouth",
-              "ukwest",
-            ]
-          }
-        }
-        access_control = {}
-      }
-    }
-    "${var.root_id_3}-customer-web-prod" = {
-      display_name               = "Prod Web Applications"
-      parent_management_group_id = "${var.root_id_3}-customer-online"
-      subscription_ids           = []
-      archetype_config = {
-        archetype_id   = "default_empty"
-        parameters     = {}
-        access_control = {}
-      }
-    }
-    "${var.root_id_3}-customer-web-test" = {
-      display_name               = "Test Web Applications"
-      parent_management_group_id = "${var.root_id_3}-customer-online"
-      subscription_ids           = []
-      archetype_config = {
-        archetype_id = "customer_online"
-        parameters = {
-          Deny-Resource-Locations = {
-            listOfAllowedLocations = [
-              "eastus",
-              "westus",
-            ]
-          }
-          Deny-RSG-Locations = {
-            listOfAllowedLocations = [
-              "eastus",
-              "westus",
-            ]
-          }
-        }
-        access_control = {}
-      }
-    }
-    "${var.root_id_3}-customer-web-dev" = {
-      display_name               = "Dev Web Applications"
-      parent_management_group_id = "${var.root_id_3}-customer-online"
-      subscription_ids           = []
-      archetype_config = {
-        archetype_id = "customer_online"
-        parameters = {
-          Deny-Resource-Locations = {
-            listOfAllowedLocations = [
-              "eastus",
-            ]
-          }
-          Deny-RSG-Locations = {
-            listOfAllowedLocations = [
-              "eastus",
-            ]
-          }
-        }
-        access_control = {}
-      }
-    }
+  # Configuration settings for core resources
+  custom_landing_zones       = local.custom_landing_zones
+  archetype_config_overrides = local.archetype_config_overrides
+  subscription_id_overrides  = local.subscription_id_overrides
 
-  }
-
-  archetype_config_overrides = {
-    root = {
-      archetype_id = "es_root"
-      parameters = {
-        Deny-Resource-Locations = {
-          listOfAllowedLocations = [
-            "eastus",
-            "eastus2",
-            "westus",
-            "northcentralus",
-            "southcentralus",
-            "uksouth",
-            "ukwest",
-          ]
-        }
-        Deny-RSG-Locations = {
-          listOfAllowedLocations = [
-            "eastus",
-            "eastus2",
-            "westus",
-            "northcentralus",
-            "southcentralus",
-            "uksouth",
-            "ukwest",
-          ]
-        }
-        Deploy-HITRUST-HIPAA = {
-          CertificateThumbprints                                        = ""
-          DeployDiagnosticSettingsforNetworkSecurityGroupsrgName        = "${var.root_id_3}-rg"
-          DeployDiagnosticSettingsforNetworkSecurityGroupsstoragePrefix = var.root_id_3
-          installedApplicationsOnWindowsVM                              = ""
-          listOfLocations = [
-            "eastus",
-          ]
-        }
-      }
-      access_control = {}
-    }
-  }
-
-  subscription_id_overrides = {
-    root           = []
-    decommissioned = []
-    sandboxes      = []
-    landing-zones  = []
-    platform       = []
-    connectivity   = []
-    management     = []
-    identity       = []
-    demo-corp      = []
-    demo-online    = []
-    demo-sap       = []
-  }
+  # Configuration settings for management resources
+  deploy_management_resources    = false
+  configure_management_resources = local.configure_management_resources
+  subscription_id_management     = data.azurerm_client_config.current.subscription_id
 
 }
 

--- a/tests/deployment/variables.tf
+++ b/tests/deployment/variables.tf
@@ -13,3 +13,7 @@ variable "root_id_3" {
 variable "root_name" {
   type = string
 }
+
+variable "location" {
+  type = string
+}

--- a/tests/scripts/tf-plan.sh
+++ b/tests/scripts/tf-plan.sh
@@ -11,6 +11,7 @@ cd "$PIPELINE_WORKSPACE/s/tests/deployment"
 
 echo "==> Planning infrastructure..."
 terraform plan \
+    -var "location=$DEFAULT_LOCATION" \
     -var "root_id_1=$TF_ROOT_ID_1" \
     -var "root_id_2=$TF_ROOT_ID_2" \
     -var "root_id_3=$TF_ROOT_ID_3" \


### PR DESCRIPTION
This PR introduces the following updates:

- The `deploy_management_resources` input variable is now decoupled from the logic used to control policy configuration in the `management` child module, allowing the `management resources` to be implemented independently from `core resources` without impacting the expected configuration specified by the `configure_management_resources` input variable.
- Test scenarios added for a custom `configure_management_resources` input variable to allow unit tests to be written to validate this functionality.
- The `connectivity_id_management` input variable now places the provided Subscription (by ID) into the `Connectivity` Management Group.
- The `identity_id_management` input variable now places the provided Subscription (by ID) into the `Identity` Management Group.
- The `subscription_id_management` input variable now places the provided Subscription (by ID) into the `Management` Management Group.