### PR TITLE
Patch bugs for release v0.3.3

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0
 
     - name: Run github/super-linter
-      uses: docker://github/super-linter:v3.15.3
+      uses: docker://github/super-linter:v4.0.2
       env:
         # Lint all code
         VALIDATE_ALL_CODEBASE: true

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -31,7 +31,7 @@ jobs:
         fetch-depth: 0
 
     - name: Run github/super-linter
-      uses: docker://github/super-linter:v4.0.2
+      uses: docker://github/super-linter:v4.1.0
       env:
         # Lint all code
         VALIDATE_ALL_CODEBASE: true

--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,8 @@ override.tf.json
 
 # Ignore Visual Studio Code config
 **/.vscode/*
+
+# Ignore Super-Linter log
+**/super-linter.report
+**/super-linter.report/*
+**/super-linter.log

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ variable "root_name" {
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "0.3.2"
+  version = "0.3.3"
 
   root_parent_id = data.azurerm_client_config.current.tenant_id
   root_id        = var.root_id

--- a/docs/wiki/[Examples]-Deploy-Custom-Landing-Zone-Archetypes.md
+++ b/docs/wiki/[Examples]-Deploy-Custom-Landing-Zone-Archetypes.md
@@ -94,7 +94,7 @@ data "azurerm_client_config" "current" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "0.3.2"
+  version = "0.3.3"
 
   root_parent_id = data.azurerm_client_config.current.tenant_id
   root_id        = var.root_id

--- a/docs/wiki/[Examples]-Deploy-Default-Configuration.md
+++ b/docs/wiki/[Examples]-Deploy-Default-Configuration.md
@@ -44,7 +44,7 @@ data "azurerm_client_config" "current" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "0.3.2"
+  version = "0.3.3"
 
   root_parent_id = data.azurerm_client_config.current.tenant_id
   root_id        = "myorg-1"

--- a/docs/wiki/[Examples]-Deploy-Demo-Landing-Zone-Archetypes.md
+++ b/docs/wiki/[Examples]-Deploy-Demo-Landing-Zone-Archetypes.md
@@ -51,7 +51,7 @@ data "azurerm_client_config" "current" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "0.3.2"
+  version = "0.3.3"
 
   root_parent_id = data.azurerm_client_config.current.tenant_id
   root_id        = "myorg-2"

--- a/docs/wiki/[Examples]-Deploy-Using-Module-Nesting.md
+++ b/docs/wiki/[Examples]-Deploy-Using-Module-Nesting.md
@@ -12,7 +12,7 @@ The extra code needed to extend your configuration, is the following:
 
 module "enterprise_scale_nested_landing_zone" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "0.3.2"
+  version = "0.3.3"
 
 
   root_parent_id            = "${var.root_id}-landing-zones"
@@ -128,7 +128,7 @@ data "azurerm_client_config" "current" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "0.3.2"
+  version = "0.3.3"
 
   root_parent_id = data.azurerm_client_config.current.tenant_id
   root_id        = var.root_id
@@ -171,7 +171,7 @@ module "enterprise_scale" {
 
 module "enterprise_scale_nested_landing_zone" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "0.3.2"
+  version = "0.3.3"
 
 
   root_parent_id            = "${var.root_id}-landing-zones"

--- a/docs/wiki/[Examples]-Expand-built-in-archetype-definitions.md
+++ b/docs/wiki/[Examples]-Expand-built-in-archetype-definitions.md
@@ -92,7 +92,7 @@ data "azurerm_client_config" "current" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "0.3.2"
+  version = "0.3.3"
 
   root_parent_id = data.azurerm_client_config.current.tenant_id
   root_id        = "myorg-1"

--- a/docs/wiki/[User-Guide]-Getting-Started.md
+++ b/docs/wiki/[User-Guide]-Getting-Started.md
@@ -40,7 +40,7 @@ Copy and paste the following 'module' block into your Terraform configuration, i
 ```hcl
 module "caf-enterprise-scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "0.3.2"
+  version = "0.3.3"
   # insert the 1 required variable here
 }
 ```

--- a/resources.management.tf
+++ b/resources.management.tf
@@ -86,7 +86,6 @@ resource "azurerm_log_analytics_linked_service" "enterprise_scale" {
   # Optional resource attributes
   read_access_id  = each.value.template.read_access_id
   write_access_id = each.value.template.write_access_id
-  tags            = each.value.template.tags
 
   # Set explicit dependency on Resource Group, Log Analytics workspace and Automation Account deployments
   depends_on = [

--- a/resources.management.tf
+++ b/resources.management.tf
@@ -49,6 +49,7 @@ resource "azurerm_log_analytics_solution" "enterprise_scale" {
   depends_on = [
     azurerm_resource_group.enterprise_scale,
     azurerm_log_analytics_workspace.enterprise_scale,
+    azurerm_automation_account.enterprise_scale,
   ]
 
 }

--- a/resources.management.tf
+++ b/resources.management.tf
@@ -45,7 +45,10 @@ resource "azurerm_log_analytics_solution" "enterprise_scale" {
   # Optional resource attributes
   tags = each.value.template.tags
 
-  # Set explicit dependency on Resource Group and Log Analytics workspace deployments
+  # Set explicit dependency on Resource Group, Log Analytics
+  # workspace and Automation Account to fix issue #109.
+  # Ideally we would limit to specific solutions, but the
+  # depends_on block only supports static values.
   depends_on = [
     azurerm_resource_group.enterprise_scale,
     azurerm_log_analytics_workspace.enterprise_scale,

--- a/tests/scripts/azp-spn-generator.sh
+++ b/tests/scripts/azp-spn-generator.sh
@@ -14,6 +14,10 @@ az login \
     --password "$ARM_CLIENT_SECRET" \
     --query [?isDefault]
 
+echo "==> Setting active Subscription..."
+az account set \
+    --subscription "$ARM_SUBSCRIPTION_ID"
+
 echo "==> Create or update Resource Group..."
 RSG_NAME="$DEFAULT_PREFIX"
 az group create \


### PR DESCRIPTION
This PR introduces the following non-breaking changes:

- Update `github/super-linter` to use latest version
- Add `github/super-linter` output files to `.gitignore`
- Add explicit dependency between `azurerm_log_analytics_solution.enterprise_scale` and `azurerm_automation_account.enterprise_scale` to fix #109
- Remove tags from `azurerm_log_analytics_linked_service.enterprise_scale` to fix #121
- Fix workflow bug for SPN Generator when multiple Subscriptions are available
- Update docs for `v0.3.3` release