### PR TITLE
Replace `rm` with `shred`

### DIFF
--- a/tests/scripts/tf-prepare.sh
+++ b/tests/scripts/tf-prepare.sh
@@ -49,7 +49,7 @@ openssl pkcs12 \
   -passout pass:"$CERTIFICATE_PASSWORD"
 
 echo "==> Deleting SPN certificate in PEM format..."
-rm "$SPN_NAME.pem"
+shred -uz "$SPN_NAME.pem"
 
 echo "==> Creating provider.tf with required_provider version and credentials..."
 cat >provider.tf <<TFCONFIG


### PR DESCRIPTION
### This PR introduces the following changes

- **New features**:
  - Test framework - replace `rm` with `shred` to securely delete private key file
