### PR TITLE
allow subnets without nsg on Firewall, Bastion and Gateway

### DIFF
--- a/modules/archetypes/lib/policy_definitions/policy_definition_es_deny_subnet_without_nsg.json
+++ b/modules/archetypes/lib/policy_definitions/policy_definition_es_deny_subnet_without_nsg.json
@@ -35,6 +35,22 @@
             "equals": "Microsoft.Network/virtualNetworks/subnets"
           },
           {
+            "field": "name",
+            "notEquals": "AzureFirewallSubnet"
+          },
+          {
+            "field": "name",
+            "notEquals": "AzureFirewallManagementSubnet"
+          },
+          {
+            "field": "name",
+            "notEquals": "AzureBastionSubnet"
+          },
+          {
+            "field": "name",
+            "notEquals": "GatewaySubnet"
+          },
+          {
             "field": "Microsoft.Network/virtualNetworks/subnets/networkSecurityGroup.id",
             "exists": "false"
           }


### PR DESCRIPTION
Exclude subnets that do not allow NSGs to be attatched to. Including Firewall, Bastion and Gateway.

solves #38 