### PR TITLE
Bugfix/management resource group custom name

### DIFF
--- a/modules/management/locals.tf
+++ b/modules/management/locals.tf
@@ -77,7 +77,7 @@ locals {
 locals {
   resource_group_name = coalesce(
     local.existing_resource_group_name,
-    try(local.custom_settings_rsg["management"].name, null),
+    try(local.custom_settings_rsg.name, null),
     "${local.resource_prefix}-mgmt",
   )
   resource_group_resource_id = "/subscriptions/${local.subscription_id}/resourceGroups/${local.resource_group_name}"


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Map for configuring custom name of management resource group had one nesting level to much.
Advanced settings map had to look like 
```hcl
advanced = {
      custom_settings_by_resource_type = {
        azurerm_resource_group = {
          management = {
            management = {
              name = "${var.customer}-${var.project}-${var.environment}-rg-management"
            }
          }
        }
        azurerm_log_analytics_workspace = {
          management = {
            name = "${var.customer}-${var.project}-${var.environment}-la-management"
          }
        }
        azurerm_automation_account = {
          management = {
            name = "${var.customer}-${var.project}-${var.environment}-aacc-management"
          }
        }
      }
    }
```
After bugfix it can look consistent like this
```hcl
advanced = {
      custom_settings_by_resource_type = {
        azurerm_resource_group = {
          management = {
            name = "${var.customer}-${var.project}-${var.environment}-rg-management"
          }
        }
        azurerm_log_analytics_workspace = {
          management = {
            name = "${var.customer}-${var.project}-${var.environment}-la-management"
          }
        }
        azurerm_automation_account = {
          management = {
            name = "${var.customer}-${var.project}-${var.environment}-aacc-management"
          }
        }
      }
    }
```

## This PR fixes

#139 

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [(X)] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
