### PR TITLE
Fix images in README.md and azp-spn-generator.sh error

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,10 +237,10 @@ module "enterprise_scale" {
  [//]: # (INSERT IMAGE REFERENCES BELOW)
  [//]: # (*****************************)
 
-[TFAES-Overview]:     ./docs/wiki/media/terraform-caf-enterprise-scale-overview.png "Diagram showing the core Cloud Adoption Framework Enterprise-scale Landing Zone architecture deployed by this module."
-[TFAES-Management]:   ./docs/wiki/media/terraform-caf-enterprise-scale-management.png "Diagram showing the Management resources for Cloud Adoption Framework Enterprise-scale Landing Zone architecture deployed by this module."
-[TFAES-Connectivity]: ./docs/wiki/media/terraform-caf-enterprise-scale-connectivity.png "Diagram showing the Connectivity resources for Cloud Adoption Framework Enterprise-scale Landing Zone architecture deployed by this module."
-[TFAES-Identity]:     ./docs/wiki/media/terraform-caf-enterprise-scale-identity.png "Diagram showing the Identity resources for Cloud Adoption Framework Enterprise-scale Landing Zone architecture deployed by this module."
+[TFAES-Overview]:     https://raw.githubusercontent.com/wiki/Azure/terraform-azurerm-caf-enterprise-scale/media/terraform-caf-enterprise-scale-overview.png "Diagram showing the core Cloud Adoption Framework Enterprise-scale Landing Zone architecture deployed by this module."
+[TFAES-Management]:   https://raw.githubusercontent.com/wiki/Azure/terraform-azurerm-caf-enterprise-scale/media/terraform-caf-enterprise-scale-management.png "Diagram showing the Management resources for Cloud Adoption Framework Enterprise-scale Landing Zone architecture deployed by this module."
+[TFAES-Connectivity]: https://raw.githubusercontent.com/wiki/Azure/terraform-azurerm-caf-enterprise-scale/media/terraform-caf-enterprise-scale-connectivity.png "Diagram showing the Connectivity resources for Cloud Adoption Framework Enterprise-scale Landing Zone architecture deployed by this module."
+[TFAES-Identity]:     https://raw.githubusercontent.com/wiki/Azure/terraform-azurerm-caf-enterprise-scale/media/terraform-caf-enterprise-scale-identity.png "Diagram showing the Identity resources for Cloud Adoption Framework Enterprise-scale Landing Zone architecture deployed by this module."
 
  [//]: # (************************)
  [//]: # (INSERT LINK LABELS BELOW)

--- a/tests/scripts/azp-spn-generator.sh
+++ b/tests/scripts/azp-spn-generator.sh
@@ -17,6 +17,8 @@ az login \
 echo "==> Setting active Subscription..."
 az account set \
     --subscription "$ARM_SUBSCRIPTION_ID"
+az account list \
+    --query "[?isDefault]"
 
 echo "==> Create or update Resource Group..."
 RSG_NAME="$DEFAULT_PREFIX"
@@ -26,14 +28,28 @@ az group create \
     --query 'properties.provisioningState' \
     --out tsv
 
+# The following logic is needed since idempotency was
+# removed from the command az keyvault create in PR:
+# https://github.com/Azure/azure-cli/pull/18520
+# Issue raised to request fix:
+# https://github.com/Azure/azure-cli/issues/19165
 echo "==> Create or update Key Vault..."
 KEY_VAULT_NAME="$DEFAULT_PREFIX-kv"
-az keyvault create \
-    --resource-group "$RSG_NAME" \
-    --name "$KEY_VAULT_NAME" \
-    --location "$DEFAULT_LOCATION" \
-    --query 'properties.provisioningState' \
-    --out tsv
+KV_EXISTS=$(
+    az keyvault list \
+        --query "[?name=='$KEY_VAULT_NAME'].name" \
+        --out tsv
+)
+if [ -z "$KV_EXISTS" ]; then
+    az keyvault create \
+        --resource-group "$RSG_NAME" \
+        --name "$KEY_VAULT_NAME" \
+        --location "$DEFAULT_LOCATION" \
+        --query 'properties.provisioningState' \
+        --out tsv
+else
+    echo "The specified vault: $KEY_VAULT_NAME already exists (skipping)"
+fi
 
 echo "==> Create or update SPNs with Role Assignments..."
 for i in {1..10}; do


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR is to address two issues:

1. Images on the default `README.md` do not render in Terraform Registry due to using relative path
2. The `azp-spn-generator.sh` script fails with error `ERROR: The specified vault: cae-estf-devops-kv already exists` since [PR #18520](https://github.com/Azure/azure-cli/pull/18520/) in the AZ CLI which breaks idempotency on this resource.

## This PR fixes/adds/changes/removes

1. Update relative paths to absolute for images in `README.md`
2. Add logic to handle idempotency issue for `az keyvault create` command in `azp-spn-generator.sh` script, replacing error with logic to skip resource creation

### Breaking Changes

*none*

## Testing Evidence

Unable to provide evidence for link updates until published to registry.

The following is from a test run of the updated `azp-spn-generator.sh` script:

![image](https://user-images.githubusercontent.com/12268562/128687356-a7e788b3-9330-4a18-ad8e-e1e8e434706a.png)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
