### PR TITLE
Add missing Deny-Private-DNS-Zone Assignment & fix private DNS auto-registration flag

### DIFF
--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_private_dns_zones.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_private_dns_zones.tmpl.json
@@ -1,0 +1,18 @@
+{
+  "name": "Deny-Private-DNS-Zones",
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2019-09-01",
+  "properties": {
+    "description": "This policy denies the creation of a private DNS in the current scope, used in combination with policies that create centralized private DNS in connectivity subscription.",
+    "displayName": "Deny the creation of private DNS",
+    "notScopes": [],
+    "parameters": {},
+    "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Private-DNS-Zones",
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": null
+  },
+  "location": "${default_location}",
+  "identity": {
+    "type": "None"
+  }
+}

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -780,7 +780,7 @@ locals {
           private_dns_zone_name = zone.name
           virtual_network_id    = link_config.resource_id
           # Optional definition attributes
-          registration_enabled = try(local.custom_settings.azurerm_private_dns_zone_virtual_network_link["connectivity"][link_config.name]["global"].registration_enabled, false)
+          registration_enabled = try(local.custom_settings.azurerm_private_dns_zone_virtual_network_link["connectivity"][link_config.name][zone.name].registration_enabled, try(local.custom_settings.azurerm_private_dns_zone_virtual_network_link["connectivity"][link_config.name]["global"].registration_enabled, false))
           tags                 = try(local.custom_settings.azurerm_private_dns_zone_virtual_network_link["connectivity"][link_config.name]["global"].tags, local.tags)
         }
       ]


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

The pull request adds the missing policy assignment Deny-Private-DNS-Zones. Moreover it fixes the auto-registration flag for private dns zones.

## This PR fixes/adds/changes/removes

1. https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/158
2. https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/157

### Breaking Changes

None

## Testing Evidence

1. The following configuration enables the auto registration feature for the private link privatelink.test.com.
```
custom_settings_by_resource_type = {
    azurerm_private_dns_zone_virtual_network_link = {
        connectivity = {
            "<SUBSCRIPTIONID>-<VNET-UUID>" = {
                "privatelink.test.com" = {
                    registration_enabled = true
                }
            }
        }
    }
}
```
2. The assignment of the policy definition Deny-Private-DNS-Zones is now successful. 

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
