### PR TITLE
Add Subscription ID to output to improve debugging

### DIFF
--- a/tests/scripts/azp-strategy.ps1
+++ b/tests/scripts/azp-strategy.ps1
@@ -94,7 +94,7 @@ for ($i = 1; $i -lt (($terraformVersionsCount * 2) + 1); $i++) {
     $aliasResponse = Invoke-AzRestMethod -Method $requestMethod -Path $requestPath -Payload $requestBody
     if ($aliasResponse.StatusCode -eq "200") {
         $subscriptionId = ($aliasResponse.Content | ConvertFrom-Json).properties.subscriptionId
-        Write-Information " Found Subscription Alias ($($alias))." -InformationAction Continue
+        Write-Information " Found Subscription Alias ($($alias)) ($($subscriptionId))." -InformationAction Continue
     }
     else {
         Write-Warning "Unable to find Subscription Alias ($($alias)). Failing back to current Subscription context ($($env:ARM_SUBSCRIPTION_ID))."
@@ -122,7 +122,7 @@ for ($i = 1; $i -lt (($terraformVersionsCount * 2) + 1); $i++) {
     $aliasResponse = Invoke-AzRestMethod -Method $requestMethod -Path $requestPath -Payload $requestBody
     if ($aliasResponse.StatusCode -eq "200") {
         $subscriptionId = ($aliasResponse.Content | ConvertFrom-Json).properties.subscriptionId
-        Write-Information " Found Subscription Alias ($($alias))." -InformationAction Continue
+        Write-Information " Found Subscription Alias ($($alias)) ($($subscriptionId))." -InformationAction Continue
     }
     else {
         Write-Warning "Unable to find Subscription Alias ($($alias)). Failing back to current Subscription context ($($env:ARM_SUBSCRIPTION_ID))."


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Improves visibility of pipeline operations when generated a matrix strategy

## This PR fixes/adds/changes/removes

1. Adds Subscription ID to output to improve debugging

### Breaking Changes

n/a

## Testing Evidence

### Before

![image](https://user-images.githubusercontent.com/12268562/143410169-7d10334c-c07a-4910-a48a-74cbc0c65532.png)

### After

![image](https://user-images.githubusercontent.com/12268562/143410516-23df1be2-7282-48b7-95bc-1a3b8d5de980.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
