### PR TITLE
Add `required_version` for Terraform

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -14,4 +14,5 @@ terraform {
       version = ">= 0.7.0"
     }
   }
+  required_version = ">= 0.15"
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Adds `required_version` to the module to [specify a required Terraform version](https://www.terraform.io/docs/language/settings/index.html#specifying-a-required-terraform-version) for the module.

## This PR fixes/adds/changes/removes

1. Fixes #229 

### Breaking Changes

none

## Testing Evidence

Unable to evidence that this prevents previous versions from working due to https://github.com/hashicorp/terraform/issues/30105

Configuration is well known setting though.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
