### PR TITLE
Update validation to fix #241

### DIFF
--- a/modules/archetypes/variables.tf
+++ b/modules/archetypes/variables.tf
@@ -9,7 +9,7 @@ variable "root_id" {
   description = "Specifies the ID of the Enterprise-scale root Management Group where Policy Definitions are created by default."
 
   validation {
-    condition     = can(regex("^/providers/Microsoft.Management/managementGroups/[a-z0-9-]{2,36}$", var.root_id))
+    condition     = can(regex("^/providers/Microsoft.Management/managementGroups/[a-zA-Z0-9-_\\(\\)\\.]{1,36}$", var.root_id))
     error_message = "The root_id value must be a valid Management Group ID."
   }
 }
@@ -19,7 +19,7 @@ variable "scope_id" {
   description = "Specifies the scope to apply the archetype resources against."
 
   validation {
-    condition     = can(regex("^/(subscriptions|providers/Microsoft.Management/managementGroups)/[a-z0-9-]{2,36}$", var.scope_id))
+    condition     = can(regex("^/(subscriptions|providers/Microsoft.Management/managementGroups)/[a-zA-Z0-9-_\\(\\)\\.]{1,36}$", var.scope_id))
     error_message = "The scope_id value must be a valid Subscription or Management Group ID."
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

- This PR applies an update to fix issue #241

## This PR fixes/adds/changes/removes

1. Update condition on validation for `scope_id` input variable in the archetype child module - fixes #241 
2. Update condition on validation for `root_id` input variable in the archetype child module for consistency and to provide better support for broader Management Group naming standards

### Breaking Changes

None

## Testing Evidence

![image](https://user-images.githubusercontent.com/12268562/146068389-642018da-c108-4241-8a40-ef7dc85ac87a.png)


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
