### PR TITLE
Update to allow mixed types in object

### DIFF
--- a/docs/wiki/[User-Guide]-Module-Variables.md
+++ b/docs/wiki/[User-Guide]-Module-Variables.md
@@ -427,7 +427,7 @@ Default: `{}`
 
 <br>
 
-[**template_file_variables**][template_file_variables] `map(any)`
+[**template_file_variables**][template_file_variables] `any`
 
 If specified, provides the ability to define custom template variables used when reading in template files from the built-in and custom library_path.
 

--- a/docs/wiki/[Variables]-template_file_variables.md
+++ b/docs/wiki/[Variables]-template_file_variables.md
@@ -1,6 +1,6 @@
 ## Overview
 
-[**template_file_variables**](#overview) `map(any)` (optional)
+[**template_file_variables**](#overview) `any` (optional)
 
 If specified, provides the ability to define custom template variables used when reading in template files from the built-in and custom library_path.
 

--- a/modules/archetypes/variables.tf
+++ b/modules/archetypes/variables.tf
@@ -54,7 +54,7 @@ variable "library_path" {
 }
 
 variable "template_file_variables" {
-  type        = map(any)
+  type        = any
   description = "If specified, provides the ability to define custom template vars used when reading in template files from the library_path"
   default     = {}
 }

--- a/variables.tf
+++ b/variables.tf
@@ -482,7 +482,7 @@ variable "library_path" {
 }
 
 variable "template_file_variables" {
-  type        = map(any)
+  type        = any
   description = "If specified, provides the ability to define custom template variables used when reading in template files from the built-in and custom library_path."
   default     = {}
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR updates the object type for the `template_file_variables` input variable to allow specifying a map of objects containing different object types.

This change is necessary due to the way `may(any)` expects the object to be a map with values of the same type.

## This PR fixes/adds/changes/removes

1. Fixes #253, adding support for mixed object types in the `template_file_variables` input variable to enable full use of the `template()` function in Terraform
2. Updates Wiki documentation to reflect this change

### Breaking Changes

None

## Testing Evidence

This change is as per the narrative in #253 and all automated tests will be used as evidence that this 

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
