### PR TITLE
Wiki sync - update on release publish

### DIFF
--- a/.github/workflows/wiki-sync.yml
+++ b/.github/workflows/wiki-sync.yml
@@ -1,11 +1,8 @@
 name: Docs/Wiki Sync
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - "docs/wiki/**"
+  release:
+    types: [published]
   workflow_dispatch: {}
 
 env:


### PR DESCRIPTION
Update wiki sync on release publish, not push to main.

Means we can update wiki source asyns whilst preparing for a release, without changing active documentation

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows?ref=hackernoon.com#release