### PR TITLE
Remove role assignment cycles

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -34,7 +34,7 @@ output "azurerm_policy_set_definition" {
 # Assignment data is returned to the root module.
 output "azurerm_management_group_policy_assignment" {
   value = {
-    enterprise_scale  = azurerm_management_group_policy_assignment.enterprise_scale
+    enterprise_scale = azurerm_management_group_policy_assignment.enterprise_scale
   }
   description = "Returns the configuration data for all Management Group Policy Assignments created by this module."
 }
@@ -43,7 +43,7 @@ output "azurerm_management_group_policy_assignment" {
 # Definition data is returned to the root module.
 output "azurerm_role_definition" {
   value = {
-    enterprise_scale  = azurerm_role_definition.enterprise_scale
+    enterprise_scale = azurerm_role_definition.enterprise_scale
   }
   description = "Returns the configuration data for all Role Definitions created by this module."
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -34,7 +34,7 @@ output "azurerm_policy_set_definition" {
 # Assignment data is returned to the root module.
 output "azurerm_management_group_policy_assignment" {
   value = {
-    enterprise_scale = azurerm_management_group_policy_assignment.enterprise_scale
+    enterprise_scale  = azurerm_management_group_policy_assignment.enterprise_scale
   }
   description = "Returns the configuration data for all Management Group Policy Assignments created by this module."
 }
@@ -43,7 +43,7 @@ output "azurerm_management_group_policy_assignment" {
 # Definition data is returned to the root module.
 output "azurerm_role_definition" {
   value = {
-    enterprise_scale = azurerm_role_definition.enterprise_scale
+    enterprise_scale  = azurerm_role_definition.enterprise_scale
   }
   description = "Returns the configuration data for all Role Definitions created by this module."
 }
@@ -52,7 +52,8 @@ output "azurerm_role_definition" {
 # Assignment data is returned to the root module.
 output "azurerm_role_assignment" {
   value = {
-    enterprise_scale = azurerm_role_assignment.enterprise_scale
+    enterprise_scale  = azurerm_role_assignment.enterprise_scale
+    policy_assignment = azurerm_role_assignment.policy_assignment
   }
   description = "Returns the configuration data for all Role Assignments created by this module."
 }

--- a/resources.role_assignments.tf
+++ b/resources.role_assignments.tf
@@ -22,6 +22,12 @@ resource "azurerm_role_assignment" "enterprise_scale" {
     time_sleep.after_azurerm_role_definition,
   ]
 
+  lifecycle {
+    ignore_changes = [
+      principal_id  # Prevent existing role assignments to be destroyed and recreated when editing policy assignment parameters
+    ]
+  }
+
 }
 
 resource "azurerm_role_assignment" "policy_assignment" {

--- a/resources.role_assignments.tf
+++ b/resources.role_assignments.tf
@@ -48,6 +48,12 @@ resource "azurerm_role_assignment" "policy_assignment" {
     time_sleep.after_azurerm_role_definition,
   ]
 
+  lifecycle {
+    ignore_changes = [
+      principal_id  # Prevent existing role assignments to be destroyed and recreated when editing policy assignment parameters
+    ]
+  }
+
 }
 
 resource "time_sleep" "after_azurerm_role_assignment" {


### PR DESCRIPTION
Prevent existing role assignments to be destroyed and recreated when editing policy assignment parameters

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR addresses the issue described in #266 



## This PR fixes/adds/changes/removes


### Breaking Changes

no breaking changes

## Testing Evidence

Editing a policy assignment parameter before the change:

![Screenshot 2022-02-07 at 08 59 41](https://user-images.githubusercontent.com/4702224/152711341-55a33e26-915e-44f6-9105-b9dc7426919a.png)

Editing a policy assignment parameter after the change:
![Screenshot 2022-02-07 at 09 24 07](https://user-images.githubusercontent.com/4702224/152711384-cf9611c7-54d1-4c9f-82fb-fd753b55a171.png)


Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
