### PR TITLE
Add `Edit-LineEndings` to simplify local running

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+# Set the default behavior, in case people don't have core.autocrlf set.
+* text=lf
+
+# Explicitly declare text files you want to always be normalized and converted
+# to native line endings on checkout.
+*.json text
+
+# Declare files that will always have CRLF line endings on checkout.
+
+# Denote all files that are truly binary and should not be modified.
+*.png binary
+*.jpg binary

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,4 @@
+[core]
+whitespace = fix,-indent-with-non-tab,trailing-space,cr-at-eol
+autocrlf = input
+longpaths = true

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,4 +1,3 @@
 [core]
-whitespace = fix,-indent-with-non-tab,trailing-space,cr-at-eol
 autocrlf = input
 longpaths = true

--- a/.github/scripts/EnterpriseScaleLibraryTools/EnterpriseScaleLibraryTools.psm1
+++ b/.github/scripts/EnterpriseScaleLibraryTools/EnterpriseScaleLibraryTools.psm1
@@ -777,7 +777,7 @@ function Edit-LineEndings {
             "unix" { $eol = "`n" }
             "win" { $eol = "`r`n" }
         }
-    
+
     }
 
     Process {

--- a/.github/scripts/Invoke-LibraryUpdate.ps1
+++ b/.github/scripts/Invoke-LibraryUpdate.ps1
@@ -23,6 +23,7 @@
 param (
     [Parameter()][String]$TargetModulePath = "$PWD/terraform-azurerm-caf-enterprise-scale",
     [Parameter()][String]$SourceModulePath = "$PWD/enterprise-scale",
+    [Parameter()][String]$LineEnding = "unix",
     [Parameter()][Switch]$Reset,
     [Parameter()][Switch]$UseCacheFromModule
 )
@@ -108,6 +109,7 @@ foreach ($config in $esltConfig) {
         -FileNameSuffix ($config.fileNameSuffix ?? $defaultConfig.fileNameSuffix) `
         -AsTemplate:($config.asTemplate ?? $defaultConfig.asTemplate) `
         -Recurse:($config.recurse ?? $defaultConfig.recurse) `
+        -LineEnding $LineEnding `
         -WhatIf:$WhatIfPreference
 }
 
@@ -134,4 +136,4 @@ $esRootConfig.es_root.policy_definitions = $policyDefinitionNames
 Write-Information "Updating Policy Set Definitions in `"es_root`" archetype definition." -InformationAction Continue
 $esRootConfig.es_root.policy_set_definitions = $policySetDefinitionNames
 Write-Information "Saving `"es_root`" archetype definition." -InformationAction Continue
-$esRootConfig | ConvertTo-Json -Depth 10 | Out-File -FilePath $esRootFilePath -Force
+$esRootConfig | ConvertTo-Json -Depth 10 | Edit-LineEndings -LineEnding $LineEnding | Out-File -FilePath $esRootFilePath -Force


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Previously, files would be created with `CRLF` line endings when running the `Invoke-LibraryUpdate` script on Windows.

This PR adds a new `Edit-LineEndings` function to simplify local running of the `Invoke-LibraryUpdate.ps1` script on different OS versions to ensure the original `LF` line endings are used.

This prevents Git from incorrectly tracking changes to files which have had the line endings incorrectly updated.

> The default is line ending type is set to `unix` (aka `LF`) on the assumption that git is configured to "check out as is". Users may need to change this value if git is configured differently.

## This PR fixes/adds/changes/removes

1. Adds a new `Edit-LineEndings` function
2. Updates the `Export-LibraryArtifact` function to use `Edit-LineEndings`
3. Updates the `Invoke-LibraryUpdate` script to use `Edit-LineEndings`

### Breaking Changes

n/a

## Testing Evidence

**Run on local machine (Windows)**

![image](https://user-images.githubusercontent.com/12268562/156148962-bf805eac-3523-4210-8fc1-721c4c56f64e.png)

**Run on GitHub runner (Linux)**

![image](https://user-images.githubusercontent.com/12268562/156150016-6d970712-7c6c-44ee-bfde-671d682bb19a.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
