### PR TITLE
Add Missing Databricks Default Policy Assignments to Corp MG to Match ALZ Accelerator Experience 

### DIFF
--- a/modules/archetypes/lib/archetype_definitions/archetype_definition_es_corp.tmpl.json
+++ b/modules/archetypes/lib/archetype_definitions/archetype_definition_es_corp.tmpl.json
@@ -2,7 +2,10 @@
     "es_corp": {
         "policy_assignments": [
             "Deny-Public-Endpoints",
-            "Deploy-Private-DNS-Zones"
+            "Deploy-Private-DNS-Zones",
+            "Deny-DataB-Pip",
+            "Deny-DataB-Sku",
+            "Deny-DataB-Vnet"
         ],
         "policy_definitions": [],
         "policy_set_definitions": [],

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_databricks_public_ip.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_databricks_public_ip.tmpl.json
@@ -1,0 +1,22 @@
+{
+  "name": "Deny-DataB-Pip",
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2019-09-01",
+  "properties": {
+    "description": "Prevent the deployment of Databricks workspaces that do not use the noPublicIp feature to host Databricks clusters without public IPs.",
+    "displayName": "Prevent usage of Databricks with public IP",
+    "notScopes": [],
+    "parameters": {
+      "effect": {
+        "value": "Deny"
+      }
+    },
+    "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Databricks-NoPublicIp",
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
+  },
+  "location": "${default_location}",
+  "identity": {
+    "type": "None"
+  }
+}

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_databricks_sku.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_databricks_sku.tmpl.json
@@ -1,0 +1,22 @@
+{
+  "name": "Deny-DataB-Sku",
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2019-09-01",
+  "properties": {
+    "description": "Enforces the use of Premium Databricks workspaces to make sure appropriate security features are available including Databricks Access Controls, Credential Passthrough and SCIM provisioning for AAD.",
+    "displayName": "Enforces the use of Premium Databricks workspaces",
+    "notScopes": [],
+    "parameters": {
+      "effect": {
+        "value": "Deny"
+      }
+    },
+    "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Databricks-Sku",
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
+  },
+  "location": "${default_location}",
+  "identity": {
+    "type": "None"
+  }
+}

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_databricks_vnet.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_databricks_vnet.tmpl.json
@@ -1,0 +1,22 @@
+{
+  "name": "Deny-DataB-Vnet",
+  "type": "Microsoft.Authorization/policyAssignments",
+  "apiVersion": "2019-09-01",
+  "properties": {
+    "description": "Enforces the use of vnet injection for Databricks workspaces.",
+    "displayName": "Enforces the use of vnet injection for Databricks",
+    "notScopes": [],
+    "parameters": {
+      "effect": {
+        "value": "Deny"
+      }
+    },
+    "policyDefinitionId": "${root_scope_resource_id}/providers/Microsoft.Authorization/policyDefinitions/Deny-Databricks-VirtualNetwork",
+    "scope": "${current_scope_resource_id}",
+    "enforcementMode": "Default"
+  },
+  "location": "${default_location}",
+  "identity": {
+    "type": "None"
+  }
+}


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Add Missing Databricks Default Policy Assignments to Corp MG to Match ALZ Accelerator Experience 

## This PR fixes/adds/changes/removes

1. Add 3 policy assignments for databricks to `corp` Management Groupto match ALZ Accelerator experience 
    - Deny-DataB-Pip
    - Deny-DataB-Sku
    - Deny-DataB-Vnet
2. Fixes #295 

### Breaking Changes

None

## Testing Evidence

Automated testing will suffice

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
