### PR TITLE
Create azurerm `< v3.0.0` constraint

### DIFF
--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 2.96.0"
+      version = ">= 2.96.0, < 3.0.0"
       configuration_aliases = [
         azurerm.connectivity,
         azurerm.management,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Add `azurerm` provider constraint so that we don't use `v3.0`. Added due to schema changes in resources that don't allow us to support the current `>= v2.96.0` providers alongside the new `v3.0`.

## This PR fixes/adds/changes/removes

* #309

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
