### PR TITLE
Fix `random_id.telem is empty tuple` error when `disable_telemetry = true`

### DIFF
--- a/locals.telemetry.connectivity.tf
+++ b/locals.telemetry.connectivity.tf
@@ -6,16 +6,16 @@
 # The following locals are used to create the bitfield data, dependent on the module configuration
 locals {
   # Bitfield bit 1 (LSB): Are hub networks configured?
-  telem_connectivity_configure_hub_networks = length(var.configure_connectivity_resources.settings.hub_networks) > 0 ? 1 : 0
+  telem_connectivity_configure_hub_networks = length(local.configure_connectivity_resources.settings.hub_networks) > 0 ? 1 : 0
 
   # Bitfield bit 2: VWAN configured?
-  telem_connectivity_configure_vwan_hub_networks = length(var.configure_connectivity_resources.settings.vwan_hub_networks) > 0 ? 2 : 0
+  telem_connectivity_configure_vwan_hub_networks = length(local.configure_connectivity_resources.settings.vwan_hub_networks) > 0 ? 2 : 0
 
   # Bitfield bit 3: Is DDOS protection configured?
-  telem_connectivity_configure_ddos_protection_plan = var.configure_connectivity_resources.settings.ddos_protection_plan.enabled ? 4 : 0
+  telem_connectivity_configure_ddos_protection_plan = local.configure_connectivity_resources.settings.ddos_protection_plan.enabled ? 4 : 0
 
   # Bitfield bit 4: DNS configured?
-  telem_connectivity_configure_dns = var.configure_connectivity_resources.settings.dns.enabled ? 8 : 0
+  telem_connectivity_configure_dns = local.configure_connectivity_resources.settings.dns.enabled ? 8 : 0
 }
 
 # The following locals calculate the telemetry bitfield by summiung thhe above locals and then representing as hexadecimal
@@ -48,5 +48,5 @@ locals {
 
 # Condition to determine whether we create the connectivity telemetry deployment
 locals {
-  telem_connectivity_deployment_enabled = !var.disable_telemetry && var.deploy_connectivity_resources
+  telem_connectivity_deployment_enabled = !local.disable_telemetry && local.deploy_connectivity_resources
 }

--- a/locals.telemetry.connectivity.tf
+++ b/locals.telemetry.connectivity.tf
@@ -39,7 +39,7 @@ locals {
       local.telem_connectivity_puid,
       local.module_version,
       local.telem_connectivity_bitfield_hex,
-      random_id.telem[0].hex
+      local.telem_random_hex,
     ),
     0,
     64

--- a/locals.telemetry.core.tf
+++ b/locals.telemetry.core.tf
@@ -6,19 +6,19 @@
 # The following locals are used to create the bitfield data, dependent on the module configuration
 locals {
   # Bitfield bit 1 (LSB): Is deploy core LZs enabled?
-  telem_core_deploy_core_landing_zones = var.deploy_core_landing_zones ? 1 : 0
+  telem_core_deploy_core_landing_zones = local.deploy_core_landing_zones ? 1 : 0
 
   # Bitfield bit 2: Is deploy corp LZ set?
-  telem_core_deploy_corp_landing_zones = var.deploy_corp_landing_zones ? 2 : 0
+  telem_core_deploy_corp_landing_zones = local.deploy_corp_landing_zones ? 2 : 0
 
   # Bitfield bit 3: Is deploy online LZ set?
-  telem_core_deploy_online_landing_zones = var.deploy_online_landing_zones ? 4 : 0
+  telem_core_deploy_online_landing_zones = local.deploy_online_landing_zones ? 4 : 0
 
   # Bitfield bit 4: Is deploy SAP LZ set?
-  telem_core_deploy_sap_landing_zones = var.deploy_online_landing_zones ? 8 : 0
+  telem_core_deploy_sap_landing_zones = local.deploy_online_landing_zones ? 8 : 0
 
   # Bitfield bit 5: Are there any custom LZs configured?
-  telem_core_custom_lzs_configured = length(var.custom_landing_zones) > 0 ? 16 : 0
+  telem_core_custom_lzs_configured = length(local.custom_landing_zones) > 0 ? 16 : 0
 }
 
 # The following locals calculate the telemetry bitfield by summiung thhe above locals and then representing as hexadecimal
@@ -52,5 +52,5 @@ locals {
 
 # Condition to determine whether we create the core telemetry deployment
 locals {
-  telem_core_deployment_enabled = !var.disable_telemetry
+  telem_core_deployment_enabled = !local.disable_telemetry
 }

--- a/locals.telemetry.core.tf
+++ b/locals.telemetry.core.tf
@@ -43,7 +43,7 @@ locals {
       local.telem_core_puid,
       local.module_version,
       local.telem_core_bitfield_hex,
-      random_id.telem[0].hex
+      local.telem_random_hex,
     ),
     0,
     64

--- a/locals.telemetry.identity.tf
+++ b/locals.telemetry.identity.tf
@@ -6,7 +6,7 @@
 # The following locals are used to create the bitfield data, dependent on the module configuration
 locals {
   # Bitfield bit 1 (LSB): Is log analytics enabled?
-  telem_identity_configure_identity_policies = var.configure_identity_resources.settings.identity.enabled ? 1 : 0
+  telem_identity_configure_identity_policies = local.configure_identity_resources.settings.identity.enabled ? 1 : 0
 }
 
 # The following locals calculate the telemetry bitfield by summiung thhe above locals and then representing as hexadecimal
@@ -36,5 +36,5 @@ locals {
 
 # Condition to determine whether we create the management telemetry deployment
 locals {
-  telem_identity_deployment_enabled = !var.disable_telemetry && var.deploy_identity_resources
+  telem_identity_deployment_enabled = !local.disable_telemetry && local.deploy_identity_resources
 }

--- a/locals.telemetry.identity.tf
+++ b/locals.telemetry.identity.tf
@@ -27,7 +27,7 @@ locals {
       local.telem_identity_puid,
       local.module_version,
       local.telem_identity_bitfield_hex,
-      random_id.telem[0].hex
+      local.telem_random_hex,
     ),
     0,
     64

--- a/locals.telemetry.management.tf
+++ b/locals.telemetry.management.tf
@@ -31,7 +31,7 @@ locals {
       local.telem_management_puid,
       local.module_version,
       local.telem_management_bitfield_hex,
-      random_id.telem[0].hex
+      local.telem_random_hex,
     ),
     0,
     64

--- a/locals.telemetry.management.tf
+++ b/locals.telemetry.management.tf
@@ -6,10 +6,10 @@
 # The following locals are used to create the bitfield data, dependent on the module configuration
 locals {
   # Bitfield bit 1 (LSB): Is log analytics enabled?
-  telem_management_configure_log_analytics = var.configure_management_resources.settings.log_analytics.enabled ? 1 : 0
+  telem_management_configure_log_analytics = local.configure_management_resources.settings.log_analytics.enabled ? 1 : 0
 
   # Bitfield bit 2: Is defender for cloud enabled (prev. Azure security center) enabled?
-  telem_management_configure_security_center = var.configure_management_resources.settings.security_center.enabled ? 2 : 0
+  telem_management_configure_security_center = local.configure_management_resources.settings.security_center.enabled ? 2 : 0
 }
 
 # The following locals calculate the telemetry bitfield by summiung thhe above locals and then representing as hexadecimal
@@ -40,5 +40,5 @@ locals {
 
 # Condition to determine whether we create the management telemetry deployment
 locals {
-  telem_management_deployment_enabled = !var.disable_telemetry && var.deploy_management_resources
+  telem_management_deployment_enabled = !local.disable_telemetry && local.deploy_management_resources
 }

--- a/locals.telemetry.tf
+++ b/locals.telemetry.tf
@@ -10,6 +10,11 @@ locals {
   telem_management_puid   = "6fffb9f9-2691-412a-837e-3f72dcfe70cb"
 }
 
+# The following `can()` is used for when disable_telemetry = true
+locals {
+  telem_random_hex = can(random_id.telem[0].hex) ? random_id.telem[0].hex : local.empty_string
+}
+
 # Here we create the ARM templates for the telemetry deployment
 locals {
   telem_arm_subscription_template_content = <<TEMPLATE

--- a/locals.tf
+++ b/locals.tf
@@ -40,6 +40,7 @@ locals {
   default_location         = var.default_location
   default_tags             = var.default_tags
   disable_base_module_tags = var.disable_base_module_tags
+  disable_telemetry        = var.disable_telemetry
 }
 
 # The following locals are used to ensure non-null values


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

When setting `disable_telemetry = true`, we observe the following error:

```shell
╷
│ Error: Invalid index
│
│   on ..\..\..\locals.telemetry.connectivity.tf line 42, in locals:
│   42:       random_id.telem[0].hex
│     ├────────────────
│     │ random_id.telem is empty tuple
│
│ The given key does not identify an element in this collection value: the collection has no elements.
╵
```

This PR implements a fix to catch this error, allowing `disable_telemetry = true` to continue controlling the `random_id.telem` resource creation as desired.

## This PR fixes/adds/changes/removes

1. Fixes the error above
2. Replaces instances of `var.` with `local.` for consistency

### Breaking Changes

n/a

## Testing Evidence

Snippet of errors before the fix:

![image](https://user-images.githubusercontent.com/12268562/161295298-85dfd42e-4636-4b4c-9e05-9fda69936370.png)

Snippet of plan when `disable_telemetry = false`:

![image](https://user-images.githubusercontent.com/12268562/161295497-5cac1886-c771-4fa3-87e2-b165bee66a1b.png)

Snippet of plan when `disable_telemetry = true`:

![image](https://user-images.githubusercontent.com/12268562/161295553-0179cec9-c97c-401a-ae5f-066c564b67d0.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
