### PR TITLE
Add additional resource types to variable validaiton

### DIFF
--- a/modules/connectivity/variables.tf
+++ b/modules/connectivity/variables.tf
@@ -313,7 +313,20 @@ variable "custom_settings_by_resource_type" {
 
   validation {
     condition = (
-      can([for k in keys(var.custom_settings_by_resource_type) : contains(["azurerm_resource_group", "azurerm_virtual_network", "azurerm_subnet", "azurerm_virtual_network_gateway", "azurerm_public_ip", "azurerm_firewall", "azurerm_network_ddos_protection_plan", "azurerm_dns_zone", "azurerm_virtual_network_peering"], k)]) ||
+      can([for k in keys(var.custom_settings_by_resource_type) : contains([
+        "azurerm_dns_zone",
+        "azurerm_firewall",
+        "azurerm_firewall_policy",
+        "azurerm_network_ddos_protection_plan",
+        "azurerm_private_dns_zone",
+        "azurerm_private_dns_zone_virtual_network_link",
+        "azurerm_public_ip",
+        "azurerm_resource_group",
+        "azurerm_subnet",
+        "azurerm_virtual_network_gateway",
+        "azurerm_virtual_network_peering",
+        "azurerm_virtual_network",
+      ], k)]) ||
       var.custom_settings_by_resource_type == {} ||
       var.custom_settings_by_resource_type == null
     )


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Related to #348

Adds advanced setting capability for new resource types released in v2.0.0

- `azurerm_private_dns_zone`
- `azurerm_private_dns_zone_virtual_network_link`
- `azurerm_firewall_policy`

## This PR fixes/adds/changes/removes

1. Adds additional resource types to the connectivity sub-module's `custom_settings_by_resource_type` variable


## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
