### PR TITLE
Add enable_bgp condition for Basic VPNGW SKU

### DIFF
--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -657,7 +657,7 @@ locals {
         )
       )
       vpn_type      = try(local.custom_settings.azurerm_virtual_network_gateway["connectivity_vpn"][location].vpn_type, "RouteBased")
-      enable_bgp    = coalesce(hub_network.config.virtual_network_gateway.config.advanced_vpn_settings.enable_bgp, false)
+      enable_bgp    = lower(hub_network.config.virtual_network_gateway.config.gateway_sku_vpn) == "basic" ? null : coalesce(hub_network.config.virtual_network_gateway.config.advanced_vpn_settings.enable_bgp, false)
       active_active = coalesce(hub_network.config.virtual_network_gateway.config.advanced_vpn_settings.active_active, false)
       private_ip_address_enabled = (
         contains(


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Added ternary operator to set enable_bgp to null if VPN SKU is Basic, otherwise set to true false as per existing coalesce function

## This PR fixes/adds/changes/removes

1. fixes #369 

## Testing Evidence

**creation of basic sku vpngw**

![image](https://user-images.githubusercontent.com/16320656/168154338-067c680b-a6c3-4587-8dd4-4879b6207761.png)

![image](https://user-images.githubusercontent.com/16320656/168154374-b8fee628-bff3-4a4f-8e0f-1e89e9ee1c79.png)

**creation of vpngw1 sku vpngw**

![image](https://user-images.githubusercontent.com/16320656/168155627-78e50108-724c-4c23-b48c-721a4ad425cb.png)



