### PR TITLE
Feature Request -  Custom Setting Support for vnet peerings

### DIFF
--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1513,7 +1513,10 @@ locals {
           resource_id       = "${local.virtual_network_resource_id[location]}/virtualNetworkPeerings/peering-${uuidv5("url", spoke_resource_id)}"
           managed_by_module = local.deploy_outbound_virtual_network_peering[location]
           # Resource definition attributes
-          name                      = "peering-${uuidv5("url", spoke_resource_id)}"
+          name = try(
+            local.custom_settings.azurerm_virtual_network_peering["connectivity"][location][spoke_resource_id].name,
+            "peering-${uuidv5("url", spoke_resource_id)}"
+          )
           resource_group_name       = local.resource_group_names_by_scope_and_location["connectivity"][location]
           virtual_network_name      = local.virtual_network_name[location]
           remote_virtual_network_id = spoke_resource_id

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -203,7 +203,6 @@ locals {
   deploy_outbound_virtual_network_peering = {
     for location, hub_network in local.hub_networks_by_location :
     location =>
-    local.deploy_dns &&
     local.deploy_hub_network[location] &&
     hub_network.config.enable_outbound_virtual_network_peering
   }
@@ -1513,10 +1512,11 @@ locals {
           resource_id       = "${local.virtual_network_resource_id[location]}/virtualNetworkPeerings/peering-${uuidv5("url", spoke_resource_id)}"
           managed_by_module = local.deploy_outbound_virtual_network_peering[location]
           # Resource definition attributes
-          name = try(
-            local.custom_settings.azurerm_virtual_network_peering["connectivity"][location][spoke_resource_id].name,
-            "peering-${uuidv5("url", spoke_resource_id)}"
-          )
+          # name = try(
+          #   local.custom_settings.azurerm_virtual_network_peering["connectivity"][location][spoke_resource_id].name,
+          #   "peering-${uuidv5("url", spoke_resource_id)}"
+          # )
+          name = "peering-${uuidv5("url", spoke_resource_id)}"
           resource_group_name       = local.resource_group_names_by_scope_and_location["connectivity"][location]
           virtual_network_name      = local.virtual_network_name[location]
           remote_virtual_network_id = spoke_resource_id

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1512,11 +1512,10 @@ locals {
           resource_id       = "${local.virtual_network_resource_id[location]}/virtualNetworkPeerings/peering-${uuidv5("url", spoke_resource_id)}"
           managed_by_module = local.deploy_outbound_virtual_network_peering[location]
           # Resource definition attributes
-          # name = try(
-          #   local.custom_settings.azurerm_virtual_network_peering["connectivity"][location][spoke_resource_id].name,
-          #   "peering-${uuidv5("url", spoke_resource_id)}"
-          # )
-          name = "peering-${uuidv5("url", spoke_resource_id)}"
+          name = try(
+            local.custom_settings.azurerm_virtual_network_peering["connectivity"][location][spoke_resource_id].name,
+            "peering-${uuidv5("url", spoke_resource_id)}"
+          )
           resource_group_name       = local.resource_group_names_by_scope_and_location["connectivity"][location]
           virtual_network_name      = local.virtual_network_name[location]
           remote_virtual_network_id = spoke_resource_id

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1502,6 +1502,29 @@ locals {
 # Configuration settings for resource type:
 #  - azurerm_virtual_network_peering
 locals {
+  virtual_network_peering_name = {
+    for location, hub_config in local.hub_networks_by_location :
+    location => {
+      for spoke_resource_id in hub_config.config.spoke_virtual_network_resource_ids :
+      spoke_resource_id => try(
+        local.custom_settings.azurerm_virtual_network_peering["connectivity"][location][spoke_resource_id].name,
+        "peering-${uuidv5("url", spoke_resource_id)}"
+      )
+    }
+  }
+  virtual_network_peering_resource_id_prefix = {
+    for location, hub_config in local.hub_networks_by_location :
+    location =>
+    "${local.virtual_network_resource_id[location]}/virtualNetworkPeerings"
+  }
+  virtual_network_peering_resource_id = {
+    for location, hub_config in local.hub_networks_by_location :
+    location => {
+      for spoke_resource_id, peering_name in local.virtual_network_peering_name[location] :
+      spoke_resource_id =>
+      "${local.virtual_network_peering_resource_id_prefix[location]}/${peering_name}"
+    }
+  }
   azurerm_virtual_network_peering = flatten(
     [
       for location, hub_config in local.hub_networks_by_location :
@@ -1509,13 +1532,10 @@ locals {
         for spoke_resource_id in hub_config.config.spoke_virtual_network_resource_ids :
         {
           # Resource logic attributes
-          resource_id       = "${local.virtual_network_resource_id[location]}/virtualNetworkPeerings/peering-${uuidv5("url", spoke_resource_id)}"
+          resource_id       = "${local.virtual_network_peering_resource_id[location][spoke_resource_id]}"
           managed_by_module = local.deploy_outbound_virtual_network_peering[location]
           # Resource definition attributes
-          name = try(
-            local.custom_settings.azurerm_virtual_network_peering["connectivity"][location][spoke_resource_id].name,
-            "peering-${uuidv5("url", spoke_resource_id)}"
-          )
+          name                      = "${local.virtual_network_peering_name[location][spoke_resource_id]}"
           resource_group_name       = local.resource_group_names_by_scope_and_location["connectivity"][location]
           virtual_network_name      = local.virtual_network_name[location]
           remote_virtual_network_id = spoke_resource_id


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Adds advanced block support for custom vnet peering naming.

## This PR fixes/adds/changes/removes

1. Fixes #397
2. Fixes #403 

### Breaking Changes

n/a

## Testing Evidence

```text
=== RUN   TestConnectivityAdvancedVnetPeeringNameNotSet
TestConnectivityAdvancedVnetPeeringNameNotSet 2022-06-15T00:18:12+01:00 /Users/matt/code/terraform-azurerm-caf-enterprise-scale/tests/terratest/connectivity/advancedVnetPeeringName/retry.go:91: terraform [init -upgrade=false]
TestConnectivityAdvancedVnetPeeringNameNotSet 2022-06-15T00:18:14+01:00 /Users/matt/code/terraform-azurerm-caf-enterprise-scale/tests/terratest/connectivity/advancedVnetPeeringName/retry.go:91: terraform [plan -input=false -lock=false -no-color -lock=false -out=./tfplan --parallelism=20]
TestConnectivityAdvancedVnetPeeringNameNotSet 2022-06-15T00:18:27+01:00 /Users/matt/code/terraform-azurerm-caf-enterprise-scale/tests/terratest/connectivity/advancedVnetPeeringName/retry.go:91: terraform [show -no-color -json ./tfplan]
    /Users/matt/code/terraform-azurerm-caf-enterprise-scale/tests/terratest/connectivity/advancedVnetPeeringName/advancedVnetPeeringName_test.go:47: Peering name: 'peering-134dd88d-86f2-5006-9401-698a1f46852e' is correct in plan
--- PASS: TestConnectivityAdvancedVnetPeeringNameNotSet (14.68s)
=== RUN   TestConnectivityAdvancedVnetPeeringNameSet
TestConnectivityAdvancedVnetPeeringNameSet 2022-06-15T00:18:27+01:00 /Users/matt/code/terraform-azurerm-caf-enterprise-scale/tests/terratest/connectivity/advancedVnetPeeringName/retry.go:91: terraform [init -upgrade=false]
TestConnectivityAdvancedVnetPeeringNameSet 2022-06-15T00:18:28+01:00 /Users/matt/code/terraform-azurerm-caf-enterprise-scale/tests/terratest/connectivity/advancedVnetPeeringName/retry.go:91: terraform [plan -input=false -lock=false -var test_advanced_name=true -no-color -lock=false -out=./tfplan --parallelism=20]
TestConnectivityAdvancedVnetPeeringNameSet 2022-06-15T00:18:40+01:00 /Users/matt/code/terraform-azurerm-caf-enterprise-scale/tests/terratest/connectivity/advancedVnetPeeringName/retry.go:91: terraform [show -no-color -json ./tfplan]
    /Users/matt/code/terraform-azurerm-caf-enterprise-scale/tests/terratest/connectivity/advancedVnetPeeringName/advancedVnetPeeringName_test.go:47: Peering name: 'test' is correct in plan
--- PASS: TestConnectivityAdvancedVnetPeeringNameSet (13.16s)
PASS
ok      github.com/Azure/terraform-azurerm-caf-enterprise-scale/tests/terratest/connectivity/advancedVnetPeeringName    28.013s


> Test run finished at 15/06/2022, 00:18:40 <
```

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
