### PR TITLE
Add option to add identity block to an Automation Account

### DIFF
--- a/modules/management/locals.tf
+++ b/modules/management/locals.tf
@@ -155,7 +155,7 @@ locals {
     name     = try(local.custom_settings_aa.name, "${local.resource_prefix}-automation${local.resource_suffix}")
     location = try(local.custom_settings_aa.location, local.location)
     sku_name = try(local.custom_settings_aa.sku_name, "Basic")
-    identity = try(local.custom_settings_aa.identity, null)
+    identity = try(local.custom_settings_aa.identity, [])
     tags     = try(local.custom_settings_aa.tags, local.tags)
     resource_group_name = coalesce(
       try(local.custom_settings_aa.resource_group_name, null),

--- a/modules/management/locals.tf
+++ b/modules/management/locals.tf
@@ -155,6 +155,7 @@ locals {
     name     = try(local.custom_settings_aa.name, "${local.resource_prefix}-automation${local.resource_suffix}")
     location = try(local.custom_settings_aa.location, local.location)
     sku_name = try(local.custom_settings_aa.sku_name, "Basic")
+    identity = try(local.custom_settings_aa.identity, null)
     tags     = try(local.custom_settings_aa.tags, local.tags)
     resource_group_name = coalesce(
       try(local.custom_settings_aa.resource_group_name, null),

--- a/modules/management/locals.tf
+++ b/modules/management/locals.tf
@@ -2,7 +2,7 @@
 # empty object types in the code.
 locals {
   empty_string = ""
-  empty_list = []
+  empty_list   = []
 }
 
 # Convert the input vars to locals, applying any required

--- a/modules/management/locals.tf
+++ b/modules/management/locals.tf
@@ -2,6 +2,7 @@
 # empty object types in the code.
 locals {
   empty_string = ""
+  empty_list = []
 }
 
 # Convert the input vars to locals, applying any required
@@ -155,7 +156,7 @@ locals {
     name     = try(local.custom_settings_aa.name, "${local.resource_prefix}-automation${local.resource_suffix}")
     location = try(local.custom_settings_aa.location, local.location)
     sku_name = try(local.custom_settings_aa.sku_name, "Basic")
-    identity = try(local.custom_settings_aa.identity, [])
+    identity = try(local.custom_settings_aa.identity, local.empty_list)
     tags     = try(local.custom_settings_aa.tags, local.tags)
     resource_group_name = coalesce(
       try(local.custom_settings_aa.resource_group_name, null),

--- a/resources.management.tf
+++ b/resources.management.tf
@@ -87,6 +87,17 @@ resource "azurerm_automation_account" "management" {
   sku_name = each.value.template.sku_name
   tags     = each.value.template.tags
 
+  # Dynamic configuration blocks
+  # Identity block
+  dynamic "identity" {
+    for_each = each.value.template.identity
+    content {
+      type = identity.value.type
+      # Optional attributes
+      identity_ids = lookup(identity.value, "identity_ids", null)
+    }
+  }
+
   # Set explicit dependency on Resource Group deployment
   depends_on = [
     azurerm_resource_group.management,


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. Fixes #398 

## Testing Evidence

```text
 ARM_SUBSCRIPTION_ID="00000000-0000-0000-0000-000000000000" make TESTPREFIX='TestManagementAdvanced' terratest
==> Running Go test...
cd tests/terratest && go test $(go list ./... |grep -v 'vendor'|grep -v 'utils')  -run ^TestManagementAdvanced
ok  	github.com/Azure/terraform-azurerm-caf-enterprise-scale/tests/terratest/connectivity/advancedVnetPeeringName	0.190s [no tests to run]
ok  	github.com/Azure/terraform-azurerm-caf-enterprise-scale/tests/terratest/management/advancedAutomationAccountIdentity	10.888s
```

Note: `identity` block must be enclosed in a list `[ ... ]`

```terraform
module "alz" {
  source  = "Azure/caf-enterprise-scale/azurerm"
  version = "2.x.x"
  # ... removed mandatory vars
  advanced = {
    custom_settings_by_resource_type = {
      azurerm_automation_account = {
        management = {
          identity = [
            {
              type = "SystemAssigned, UserAssigned"
              identity_ids = [
                "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/test/providers/Microsoft.ManagedIdentity/userAssignedIdentities/test-id"
              ]
            }
          ]
        }
      }
    }
  }
}

```

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
