### PR TITLE
Update validation for `custom_landing_zones`

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -663,7 +663,7 @@ variable "custom_landing_zones" {
   default     = {}
 
   validation {
-    condition     = can([for k in keys(var.custom_landing_zones) : regex("^[a-z0-9-]{2,36}$", k)]) || length(keys(var.custom_landing_zones)) == 0
+    condition     = can([for k in keys(var.custom_landing_zones) : regex("^[a-zA-Z0-9-]{2,36}$", k)]) || length(keys(var.custom_landing_zones)) == 0
     error_message = "The custom_landing_zones keys must be between 2 to 36 characters long and can only contain lowercase letters, numbers and hyphens."
   }
 }


### PR DESCRIPTION
<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR updates the validation logic for `custom_landing_zones` to match those of other inputs.

## This PR fixes/adds/changes/removes

1. Fix Azure/Azure-Landing-Zones#3735

### Breaking Changes

n/a

## Testing Evidence

Example of changed values showing successful plan using mixed casing and numbers in `root_id` input variable:

![image](https://user-images.githubusercontent.com/12268562/176642349-2d9d5c8d-d6e7-4a3b-a3bc-f242cb1755e4.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
