### PR TITLE
feat!: implement hub network mesh peering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,9 @@ override.tf.json
 # Ignore any files with .ignore. in the filename
 *.ignore.*
 
+# Ignore test_local
+tests/modules/test_local
+
 # Ignore macOS .DS_Store files which are generated automatically by Finder.
 .DS_Store
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Azure landing zones Terraform module
 
-[![Build Status](https://dev.azure.com/mscet/CAE-ALZ-Terraform/_apis/build/status/Tests/E2E?branchName=refs%2Ftags%2Fv2.1.2)](https://dev.azure.com/mscet/CAE-ALZ-Terraform/_build/latest?definitionId=26&branchName=refs%2Ftags%2Fv2.1.2)
+[![Build Status](https://dev.azure.com/mscet/CAE-ALZ-Terraform/_apis/build/status/Tests/E2E?branchName=refs%2Ftags%2Fv2.2.0)](https://dev.azure.com/mscet/CAE-ALZ-Terraform/_build/latest?definitionId=26&branchName=refs%2Ftags%2Fv2.2.0)
 ![GitHub release (latest SemVer)](https://img.shields.io/github/v/release/Azure/terraform-azurerm-caf-enterprise-scale?style=flat&logo=github)
 
 Detailed information about how to use, configure and extend this module can be found on our Wiki:
@@ -94,7 +94,7 @@ variable "root_name" {
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Examples]-Deploy-Connectivity-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Connectivity-Resources-With-Custom-Settings.md
@@ -139,7 +139,7 @@ data "azurerm_client_config" "core" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Examples]-Deploy-Connectivity-Resources.md
+++ b/docs/wiki/[Examples]-Deploy-Connectivity-Resources.md
@@ -70,7 +70,7 @@ data "azurerm_client_config" "core" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Examples]-Deploy-Custom-Landing-Zone-Archetypes.md
+++ b/docs/wiki/[Examples]-Deploy-Custom-Landing-Zone-Archetypes.md
@@ -95,7 +95,7 @@ data "azurerm_client_config" "core" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Examples]-Deploy-Default-Configuration.md
+++ b/docs/wiki/[Examples]-Deploy-Default-Configuration.md
@@ -45,7 +45,7 @@ data "azurerm_client_config" "core" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Examples]-Deploy-Demo-Landing-Zone-Archetypes.md
+++ b/docs/wiki/[Examples]-Deploy-Demo-Landing-Zone-Archetypes.md
@@ -52,7 +52,7 @@ data "azurerm_client_config" "core" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Examples]-Deploy-Identity-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Identity-Resources-With-Custom-Settings.md
@@ -101,7 +101,7 @@ data "azurerm_client_config" "core" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Examples]-Deploy-Identity-Resources.md
+++ b/docs/wiki/[Examples]-Deploy-Identity-Resources.md
@@ -60,7 +60,7 @@ data "azurerm_client_config" "core" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Examples]-Deploy-Management-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Management-Resources-With-Custom-Settings.md
@@ -131,7 +131,7 @@ data "azurerm_client_config" "core" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Examples]-Deploy-Management-Resources.md
+++ b/docs/wiki/[Examples]-Deploy-Management-Resources.md
@@ -61,7 +61,7 @@ data "azurerm_client_config" "core" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Examples]-Deploy-Using-Module-Nesting.md
+++ b/docs/wiki/[Examples]-Deploy-Using-Module-Nesting.md
@@ -13,7 +13,7 @@ The extra code needed to extend your configuration, is the following:
 
 module "enterprise_scale_nested_landing_zone" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm
@@ -135,7 +135,7 @@ data "azurerm_client_config" "core" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm
@@ -184,7 +184,7 @@ module "enterprise_scale" {
 
 module "enterprise_scale_nested_landing_zone" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources-With-Custom-Settings.md
@@ -137,7 +137,7 @@ data "azurerm_client_config" "core" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources.md
+++ b/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources.md
@@ -77,7 +77,7 @@ data "azurerm_client_config" "core" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Examples]-Expand-built-in-archetype-definitions.md
+++ b/docs/wiki/[Examples]-Expand-built-in-archetype-definitions.md
@@ -97,7 +97,7 @@ data "azurerm_client_config" "core" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Examples]-Override-Module-Role-Assignments.md
+++ b/docs/wiki/[Examples]-Override-Module-Role-Assignments.md
@@ -103,7 +103,7 @@ data "azurerm_client_config" "core" {}
 
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[User-Guide]-Getting-Started.md
+++ b/docs/wiki/[User-Guide]-Getting-Started.md
@@ -73,7 +73,7 @@ Copy and paste the following 'module' block into your Terraform configuration, i
 ```hcl
 module "caf-enterprise-scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[User-Guide]-Module-Releases.md
+++ b/docs/wiki/[User-Guide]-Module-Releases.md
@@ -61,7 +61,7 @@ To do this, you would use the following version constraint syntax:
 ```terraform
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   # Insert provider block and input variables here
 }
@@ -74,7 +74,7 @@ To allow automatic upgrades to the latest patch release, use the following versi
 ```terraform
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "~> 2.1.2"
+  version = "~> 2.2.0"
 
   # Insert provider block and input variables here
 }

--- a/docs/wiki/[User-Guide]-Provider-Configuration.md
+++ b/docs/wiki/[User-Guide]-Provider-Configuration.md
@@ -70,7 +70,7 @@ provider "azurerm" {
 
 module "caf-enterprise-scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm
@@ -150,7 +150,7 @@ provider "azurerm" {
 
 module "caf-enterprise-scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm
@@ -208,7 +208,7 @@ data "azurerm_client_config" "connectivity" {
 # Map each module provider to their corresponding `azurerm` provider using the providers input object
 module "enterprise_scale" {
   source  = "Azure/caf-enterprise-scale/azurerm"
-  version = "2.1.2"
+  version = "2.2.0"
 
   providers = {
     azurerm              = azurerm

--- a/docs/wiki/[Variables]-configure_connectivity_resources.md
+++ b/docs/wiki/[Variables]-configure_connectivity_resources.md
@@ -60,6 +60,7 @@ If specified, will customize the "connectivity" landing zone settings and resour
           }
           spoke_virtual_network_resource_ids      = []
           enable_outbound_virtual_network_peering = false
+          enable_hub_network_mesh_peering         = false
         }
       },
     ]
@@ -278,6 +279,7 @@ object({
           })
           spoke_virtual_network_resource_ids      = list(string)
           enable_outbound_virtual_network_peering = bool
+          enable_hub_network_mesh_peering         = bool
         })
       })
     )

--- a/docs/wiki/[Variables]-configure_connectivity_resources.settings.hub_networks.md
+++ b/docs/wiki/[Variables]-configure_connectivity_resources.settings.hub_networks.md
@@ -57,6 +57,7 @@ For each configuration object added to the `configure_connectivity_resources.set
     }
     spoke_virtual_network_resource_ids      = []
     enable_outbound_virtual_network_peering = false
+    enable_hub_network_mesh_peering         = false
   }
 }
 ```
@@ -162,6 +163,7 @@ object({
     })
     spoke_virtual_network_resource_ids      = list(string)
     enable_outbound_virtual_network_peering = bool
+    enable_hub_network_mesh_peering         = bool
   })
 })
 ```
@@ -460,6 +462,10 @@ List of Azure Resource IDs used to identify spoke Virtual Networks associated wi
 > This prevents us from creating the spoke-to-hub-peering.
 >
 > We are working on a solution for this using the recently released [AzAPI provider][tf_reg_azapi] which allows a single provider to deploy resources into multiple subscriptions using a [parent_id][tf_reg_azapi_parent_id] input.
+
+#### `config.enable_hub_network_mesh_peering`
+
+`bool` input to control whether the module will create fully meshed Virtual Network peerings between the hub networks that have this setting enabled.
 
 [//]: # "************************"
 [//]: # "INSERT LINK LABELS BELOW"

--- a/docs/wiki/[Variables]-strict_subscription_association.md
+++ b/docs/wiki/[Variables]-strict_subscription_association.md
@@ -6,22 +6,22 @@
 If set to true, subscriptions associated to management groups will be exclusively set by the module and any added by another process will be removed.
 If set to false, the module will will only enforce association of the specified subscriptions and those added to management groups by other processes will not be removed.
 
+Note that platform subscriptions should always be associated to their respective management groups using this module, due to other dependencies on these inputs.
+
+For more information, please refer to:
+
+- [`subscription_id_connectivity`][subscription_id_connectivity]
+- [`subscription_id_identity`][subscription_id_identity]
+- [`subscription_id_management`][subscription_id_management]
+
 > **Important**
-> Migration from strict to non-strict is not idempotent, this is due to the behavior of the AzureRM provider. If you are setting this variable to `false` you must either:
+>
+> Migration from strict to non-strict is not idempotent, this is due to the behavior of the AzureRM provider. If you are setting this variable to `false` with an existing config, you must either:
 >
 > - Remove all platform & other managed subscriptions associated to management groups to another place, e.g. the tenant root group. The module will then put them back; Or,
 > - Perform a Terraform import of the management group subscription association. The address of the Terraform resource for the import is is:
 > `module.MODULENAME.azurerm_management_group_subscription_association.enterprise_scale["/providers/Microsoft.Management/managementGroups/MGNAME/subscriptions/SUBID"]`.
 > The Azure resource ID should be the same as the key name (in square brackets `[]` ).
-
-> **Note:**
-> Platform subscriptions should always be associated to their respective management groups using this module, due to other dependencies on these inputs.
->
-> For more information, please refer to:
->
-> - [`subscription_id_connectivity`][subscription_id_connectivity]
-> - [`subscription_id_identity`][subscription_id_identity]
-> - [`subscription_id_management`][subscription_id_management]
 
 ## Default value
 

--- a/docs/wiki/[Variables]-strict_subscription_association.md
+++ b/docs/wiki/[Variables]-strict_subscription_association.md
@@ -6,6 +6,14 @@
 If set to true, subscriptions associated to management groups will be exclusively set by the module and any added by another process will be removed.
 If set to false, the module will will only enforce association of the specified subscriptions and those added to management groups by other processes will not be removed.
 
+> **Important**
+> Migration from strict to non-strict is not idempotent, this is due to the behavior of the AzureRM provider. If you are setting this variable to `false` you must either:
+>
+> - Remove all platform & other managed subscriptions associated to management groups to another place, e.g. the tenant root group. The module will then put them back; Or,
+> - Perform a Terraform import of the management group subscription association. The address of the Terraform resource for the import is is:
+> `module.MODULENAME.azurerm_management_group_subscription_association.enterprise_scale["/providers/Microsoft.Management/managementGroups/MGNAME/subscriptions/SUBID"]`.
+> The Azure resource ID should be the same as the key name (in square brackets `[]` ).
+
 > **Note:**
 > Platform subscriptions should always be associated to their respective management groups using this module, due to other dependencies on these inputs.
 >

--- a/locals.version.tf
+++ b/locals.version.tf
@@ -1,3 +1,3 @@
 locals {
-  module_version = "v2.1.2"
+  module_version = "v2.2.0"
 }

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1546,7 +1546,7 @@ locals {
         virtual_network_peering_name        = local.virtual_network_hub_peering_name[location_src][location_dst]
         virtual_network_peering_resource_id = "${local.virtual_network_resource_id[location_src]}/virtualNetworkPeerings/${local.virtual_network_hub_peering_name[location_src][location_dst]}"
       } if location_src != location_dst && hub_config_dst.config.enable_hub_network_mesh_peering
-    } if hub_config_src.config.enable_hub_network_mesh_peering
+    } if hub_config_src.config.enable_hub_network_mesh_peering && hub_config_src.enabled && local.enabled
   }
   azurerm_virtual_network_peering_hubs = flatten(
     [

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1534,9 +1534,9 @@ locals {
       location_dst => {
         remote_virtual_network_id           = local.virtual_network_resource_id[location_dst]
         virtual_network_peering_name        = "peering-${uuidv5("url", local.virtual_network_resource_id[location_dst])}"
-        virtual_network_peering_resource_id = "${local.virtual_network_resource_id[location]}/virtualNetworkPeerings/peering-${uuidv5("url", local.virtual_network_resource_id[location_dst])}"
-      } if location_src != location_dst && hub_config_dst.peer_hub_networks
-    } if hub_config_src.config.peer_hub_networks
+        virtual_network_peering_resource_id = "${local.virtual_network_resource_id[location_dst]}/virtualNetworkPeerings/peering-${uuidv5("url", local.virtual_network_resource_id[location_dst])}"
+      } if location_src != location_dst && hub_config_dst.config.enable_hub_network_mesh_peering
+    } if hub_config_src.config.enable_hub_network_mesh_peering
   }
   azurerm_virtual_network_peering_hubs = flatten(
     [
@@ -1584,10 +1584,10 @@ locals {
       ]
     ]
   )
-  azurerm_virtual_network_peering = merge(
-    local.azurerm_virtual_network_peering_hubs,
-    local.azurerm_virtual_network_peering_spokes
-  )
+  azurerm_virtual_network_peering = flatten([
+    [ for p in local.azurerm_virtual_network_peering_hubs : p],
+    [ for p in local.azurerm_virtual_network_peering_spokes : p]
+  ])
 }
 
 # Configuration settings for resource type:

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1585,8 +1585,8 @@ locals {
     ]
   )
   azurerm_virtual_network_peering = flatten([
-    [ for p in local.azurerm_virtual_network_peering_hubs : p],
-    [ for p in local.azurerm_virtual_network_peering_spokes : p]
+    [for p in local.azurerm_virtual_network_peering_hubs : p],
+    [for p in local.azurerm_virtual_network_peering_spokes : p]
   ])
 }
 

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -207,6 +207,12 @@ locals {
     local.deploy_hub_network[location] &&
     hub_network.config.enable_outbound_virtual_network_peering
   }
+  deploy_hub_virtual_network_mesh_peering = {
+    for location, hub_network in local.hub_networks_by_location :
+    location =>
+    local.deploy_hub_network[location] &&
+    hub_network.config.enable_hub_network_mesh_peering
+  }
 }
 
 # Logic to determine whether specific resources
@@ -1546,7 +1552,7 @@ locals {
         virtual_network_peering_name        = local.virtual_network_hub_peering_name[location_src][location_dst]
         virtual_network_peering_resource_id = "${local.virtual_network_resource_id[location_src]}/virtualNetworkPeerings/${local.virtual_network_hub_peering_name[location_src][location_dst]}"
       } if location_src != location_dst && hub_config_dst.config.enable_hub_network_mesh_peering
-    } if hub_config_src.config.enable_hub_network_mesh_peering && hub_config_src.enabled && local.enabled
+    } if hub_config_src.config.enable_hub_network_mesh_peering
   }
   azurerm_virtual_network_peering_hubs = flatten(
     [
@@ -1556,7 +1562,7 @@ locals {
         {
           # Resource logic attributes
           resource_id       = peerconfig.virtual_network_peering_resource_id
-          managed_by_module = true
+          managed_by_module = local.deploy_hub_virtual_network_mesh_peering[location_src]
           # Resource definition attributes
           name                      = peerconfig.virtual_network_peering_name
           resource_group_name       = local.resource_group_names_by_scope_and_location["connectivity"][location_src]

--- a/modules/connectivity/variables.tf
+++ b/modules/connectivity/variables.tf
@@ -135,6 +135,7 @@ variable "settings" {
           })
           spoke_virtual_network_resource_ids      = list(string)
           enable_outbound_virtual_network_peering = bool
+          enable_hub_network_mesh_peering         = bool
         })
       })
     )

--- a/resources.management_groups.tf
+++ b/resources.management_groups.tf
@@ -84,7 +84,13 @@ resource "azurerm_management_group_subscription_association" "enterprise_scale" 
   subscription_id     = each.value.subscription_id
 
   depends_on = [
-    time_sleep.after_azurerm_management_group
+    time_sleep.after_azurerm_management_group,
+    azurerm_management_group.level_1,
+    azurerm_management_group.level_2,
+    azurerm_management_group.level_3,
+    azurerm_management_group.level_4,
+    azurerm_management_group.level_5,
+    azurerm_management_group.level_6,
   ]
 }
 

--- a/tests/modules/settings/settings.connectivity.tf
+++ b/tests/modules/settings/settings.connectivity.tf
@@ -49,6 +49,7 @@ locals {
             }
             spoke_virtual_network_resource_ids      = []
             enable_outbound_virtual_network_peering = false
+            enable_hub_network_mesh_peering         = true
           }
         },
         {
@@ -97,6 +98,7 @@ locals {
             }
             spoke_virtual_network_resource_ids      = []
             enable_outbound_virtual_network_peering = false
+            enable_hub_network_mesh_peering         = true
           }
         },
       ]

--- a/tests/modules/test_002_add_custom_core/baseline_values.json
+++ b/tests/modules/test_002_add_custom_core/baseline_values.json
@@ -506,7 +506,10 @@
                 {
                   "connectivity": [
                     "tuple",
-                    []
+                    [
+                      "string",
+                      "string"
+                    ]
                   ]
                 }
               ],
@@ -848,7 +851,10 @@
             "connectivity": []
           },
           "azurerm_virtual_network_peering": {
-            "connectivity": []
+            "connectivity": [
+              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626"
+            ]
           },
           "azurerm_virtual_wan": {
             "virtual_wan": []
@@ -6406,6 +6412,48 @@
               "template_content": "{\"$schema\":\"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#\",\"contentVersion\":\"1.0.0.0\",\"outputs\":{\"telemetry\":{\"type\":\"String\",\"value\":\"For more information, see https://aka.ms/alz/tf/telemetry\"}},\"parameters\":{},\"resources\":[],\"variables\":{}}",
               "template_spec_version_id": null,
               "timeouts": null
+            },
+            "sensitive_values": {}
+          },
+          {
+            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0\"]",
+            "mode": "managed",
+            "type": "azurerm_virtual_network_peering",
+            "name": "connectivity",
+            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+            "provider_name": "registry.terraform.io/hashicorp/azurerm",
+            "schema_version": 0,
+            "values": {
+              "allow_forwarded_traffic": true,
+              "allow_gateway_transit": true,
+              "allow_virtual_network_access": true,
+              "name": "peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope",
+              "resource_group_name": "root-id-1-connectivity-westeurope",
+              "timeouts": null,
+              "use_remote_gateways": false,
+              "virtual_network_name": "root-id-1-hub-westeurope"
+            },
+            "sensitive_values": {}
+          },
+          {
+            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626\"]",
+            "mode": "managed",
+            "type": "azurerm_virtual_network_peering",
+            "name": "connectivity",
+            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
+            "provider_name": "registry.terraform.io/hashicorp/azurerm",
+            "schema_version": 0,
+            "values": {
+              "allow_forwarded_traffic": true,
+              "allow_gateway_transit": true,
+              "allow_virtual_network_access": true,
+              "name": "peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
+              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope",
+              "resource_group_name": "root-id-1-connectivity-northeurope",
+              "timeouts": null,
+              "use_remote_gateways": false,
+              "virtual_network_name": "root-id-1-hub-northeurope"
             },
             "sensitive_values": {}
           },

--- a/tests/modules/test_002_add_custom_core/baseline_values.json
+++ b/tests/modules/test_002_add_custom_core/baseline_values.json
@@ -506,10 +506,7 @@
                 {
                   "connectivity": [
                     "tuple",
-                    [
-                      "string",
-                      "string"
-                    ]
+                    []
                   ]
                 }
               ],
@@ -851,10 +848,7 @@
             "connectivity": []
           },
           "azurerm_virtual_network_peering": {
-            "connectivity": [
-              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
-              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0"
-            ]
+            "connectivity": []
           },
           "azurerm_virtual_wan": {
             "virtual_wan": []
@@ -6412,48 +6406,6 @@
               "template_content": "{\"$schema\":\"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#\",\"contentVersion\":\"1.0.0.0\",\"outputs\":{\"telemetry\":{\"type\":\"String\",\"value\":\"For more information, see https://aka.ms/alz/tf/telemetry\"}},\"parameters\":{},\"resources\":[],\"variables\":{}}",
               "template_spec_version_id": null,
               "timeouts": null
-            },
-            "sensitive_values": {}
-          },
-          {
-            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626\"]",
-            "mode": "managed",
-            "type": "azurerm_virtual_network_peering",
-            "name": "connectivity",
-            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
-            "provider_name": "registry.terraform.io/hashicorp/azurerm",
-            "schema_version": 0,
-            "values": {
-              "allow_forwarded_traffic": true,
-              "allow_gateway_transit": true,
-              "allow_virtual_network_access": true,
-              "name": "peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
-              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope",
-              "resource_group_name": "root-id-1-connectivity-northeurope",
-              "timeouts": null,
-              "use_remote_gateways": false,
-              "virtual_network_name": "root-id-1-hub-northeurope"
-            },
-            "sensitive_values": {}
-          },
-          {
-            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0\"]",
-            "mode": "managed",
-            "type": "azurerm_virtual_network_peering",
-            "name": "connectivity",
-            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
-            "provider_name": "registry.terraform.io/hashicorp/azurerm",
-            "schema_version": 0,
-            "values": {
-              "allow_forwarded_traffic": true,
-              "allow_gateway_transit": true,
-              "allow_virtual_network_access": true,
-              "name": "peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
-              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope",
-              "resource_group_name": "root-id-1-connectivity-westeurope",
-              "timeouts": null,
-              "use_remote_gateways": false,
-              "virtual_network_name": "root-id-1-hub-westeurope"
             },
             "sensitive_values": {}
           },

--- a/tests/modules/test_002_add_custom_core/baseline_values.json
+++ b/tests/modules/test_002_add_custom_core/baseline_values.json
@@ -852,8 +852,8 @@
           },
           "azurerm_virtual_network_peering": {
             "connectivity": [
-              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
-              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626"
+              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
+              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0"
             ]
           },
           "azurerm_virtual_wan": {
@@ -6416,32 +6416,11 @@
             "sensitive_values": {}
           },
           {
-            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0\"]",
+            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626\"]",
             "mode": "managed",
             "type": "azurerm_virtual_network_peering",
             "name": "connectivity",
-            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
-            "provider_name": "registry.terraform.io/hashicorp/azurerm",
-            "schema_version": 0,
-            "values": {
-              "allow_forwarded_traffic": true,
-              "allow_gateway_transit": true,
-              "allow_virtual_network_access": true,
-              "name": "peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
-              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope",
-              "resource_group_name": "root-id-1-connectivity-westeurope",
-              "timeouts": null,
-              "use_remote_gateways": false,
-              "virtual_network_name": "root-id-1-hub-westeurope"
-            },
-            "sensitive_values": {}
-          },
-          {
-            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626\"]",
-            "mode": "managed",
-            "type": "azurerm_virtual_network_peering",
-            "name": "connectivity",
-            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
+            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
             "provider_name": "registry.terraform.io/hashicorp/azurerm",
             "schema_version": 0,
             "values": {
@@ -6454,6 +6433,27 @@
               "timeouts": null,
               "use_remote_gateways": false,
               "virtual_network_name": "root-id-1-hub-northeurope"
+            },
+            "sensitive_values": {}
+          },
+          {
+            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0\"]",
+            "mode": "managed",
+            "type": "azurerm_virtual_network_peering",
+            "name": "connectivity",
+            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+            "provider_name": "registry.terraform.io/hashicorp/azurerm",
+            "schema_version": 0,
+            "values": {
+              "allow_forwarded_traffic": true,
+              "allow_gateway_transit": true,
+              "allow_virtual_network_access": true,
+              "name": "peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope",
+              "resource_group_name": "root-id-1-connectivity-westeurope",
+              "timeouts": null,
+              "use_remote_gateways": false,
+              "virtual_network_name": "root-id-1-hub-westeurope"
             },
             "sensitive_values": {}
           },

--- a/tests/modules/test_003_add_mgmt_conn/baseline_values.json
+++ b/tests/modules/test_003_add_mgmt_conn/baseline_values.json
@@ -1656,8 +1656,8 @@
           },
           "azurerm_virtual_network_peering": {
             "connectivity": [
-              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
-              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626"
+              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
+              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0"
             ]
           },
           "azurerm_virtual_wan": {
@@ -1979,8 +1979,8 @@
           },
           "azurerm_virtual_network_peering": {
             "connectivity": [
-              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
-              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626"
+              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
+              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0"
             ]
           },
           "azurerm_virtual_wan": {
@@ -3586,32 +3586,11 @@
             }
           },
           {
-            "address": "module.test_connectivity.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0\"]",
+            "address": "module.test_connectivity.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626\"]",
             "mode": "managed",
             "type": "azurerm_virtual_network_peering",
             "name": "connectivity",
-            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
-            "provider_name": "registry.terraform.io/hashicorp/azurerm",
-            "schema_version": 0,
-            "values": {
-              "allow_forwarded_traffic": true,
-              "allow_gateway_transit": true,
-              "allow_virtual_network_access": true,
-              "name": "peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
-              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope",
-              "resource_group_name": "root-id-1-connectivity-westeurope",
-              "timeouts": null,
-              "use_remote_gateways": false,
-              "virtual_network_name": "root-id-1-hub-westeurope"
-            },
-            "sensitive_values": {}
-          },
-          {
-            "address": "module.test_connectivity.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626\"]",
-            "mode": "managed",
-            "type": "azurerm_virtual_network_peering",
-            "name": "connectivity",
-            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
+            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
             "provider_name": "registry.terraform.io/hashicorp/azurerm",
             "schema_version": 0,
             "values": {
@@ -3624,6 +3603,27 @@
               "timeouts": null,
               "use_remote_gateways": false,
               "virtual_network_name": "root-id-1-hub-northeurope"
+            },
+            "sensitive_values": {}
+          },
+          {
+            "address": "module.test_connectivity.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0\"]",
+            "mode": "managed",
+            "type": "azurerm_virtual_network_peering",
+            "name": "connectivity",
+            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+            "provider_name": "registry.terraform.io/hashicorp/azurerm",
+            "schema_version": 0,
+            "values": {
+              "allow_forwarded_traffic": true,
+              "allow_gateway_transit": true,
+              "allow_virtual_network_access": true,
+              "name": "peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope",
+              "resource_group_name": "root-id-1-connectivity-westeurope",
+              "timeouts": null,
+              "use_remote_gateways": false,
+              "virtual_network_name": "root-id-1-hub-westeurope"
             },
             "sensitive_values": {}
           },
@@ -9176,32 +9176,11 @@
             "sensitive_values": {}
           },
           {
-            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0\"]",
+            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626\"]",
             "mode": "managed",
             "type": "azurerm_virtual_network_peering",
             "name": "connectivity",
-            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
-            "provider_name": "registry.terraform.io/hashicorp/azurerm",
-            "schema_version": 0,
-            "values": {
-              "allow_forwarded_traffic": true,
-              "allow_gateway_transit": true,
-              "allow_virtual_network_access": true,
-              "name": "peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
-              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope",
-              "resource_group_name": "root-id-1-connectivity-westeurope",
-              "timeouts": null,
-              "use_remote_gateways": false,
-              "virtual_network_name": "root-id-1-hub-westeurope"
-            },
-            "sensitive_values": {}
-          },
-          {
-            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626\"]",
-            "mode": "managed",
-            "type": "azurerm_virtual_network_peering",
-            "name": "connectivity",
-            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
+            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
             "provider_name": "registry.terraform.io/hashicorp/azurerm",
             "schema_version": 0,
             "values": {
@@ -9214,6 +9193,27 @@
               "timeouts": null,
               "use_remote_gateways": false,
               "virtual_network_name": "root-id-1-hub-northeurope"
+            },
+            "sensitive_values": {}
+          },
+          {
+            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0\"]",
+            "mode": "managed",
+            "type": "azurerm_virtual_network_peering",
+            "name": "connectivity",
+            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+            "provider_name": "registry.terraform.io/hashicorp/azurerm",
+            "schema_version": 0,
+            "values": {
+              "allow_forwarded_traffic": true,
+              "allow_gateway_transit": true,
+              "allow_virtual_network_access": true,
+              "name": "peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope",
+              "resource_group_name": "root-id-1-connectivity-westeurope",
+              "timeouts": null,
+              "use_remote_gateways": false,
+              "virtual_network_name": "root-id-1-hub-westeurope"
             },
             "sensitive_values": {}
           },

--- a/tests/modules/test_003_add_mgmt_conn/baseline_values.json
+++ b/tests/modules/test_003_add_mgmt_conn/baseline_values.json
@@ -862,10 +862,7 @@
                 {
                   "connectivity": [
                     "tuple",
-                    [
-                      "string",
-                      "string"
-                    ]
+                    []
                   ]
                 }
               ],
@@ -1978,10 +1975,7 @@
             "connectivity": []
           },
           "azurerm_virtual_network_peering": {
-            "connectivity": [
-              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
-              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0"
-            ]
+            "connectivity": []
           },
           "azurerm_virtual_wan": {
             "virtual_wan": []
@@ -9172,48 +9166,6 @@
               "template_content": "{\"$schema\":\"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#\",\"contentVersion\":\"1.0.0.0\",\"outputs\":{\"telemetry\":{\"type\":\"String\",\"value\":\"For more information, see https://aka.ms/alz/tf/telemetry\"}},\"parameters\":{},\"resources\":[],\"variables\":{}}",
               "template_spec_version_id": null,
               "timeouts": null
-            },
-            "sensitive_values": {}
-          },
-          {
-            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626\"]",
-            "mode": "managed",
-            "type": "azurerm_virtual_network_peering",
-            "name": "connectivity",
-            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
-            "provider_name": "registry.terraform.io/hashicorp/azurerm",
-            "schema_version": 0,
-            "values": {
-              "allow_forwarded_traffic": true,
-              "allow_gateway_transit": true,
-              "allow_virtual_network_access": true,
-              "name": "peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
-              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope",
-              "resource_group_name": "root-id-1-connectivity-northeurope",
-              "timeouts": null,
-              "use_remote_gateways": false,
-              "virtual_network_name": "root-id-1-hub-northeurope"
-            },
-            "sensitive_values": {}
-          },
-          {
-            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0\"]",
-            "mode": "managed",
-            "type": "azurerm_virtual_network_peering",
-            "name": "connectivity",
-            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
-            "provider_name": "registry.terraform.io/hashicorp/azurerm",
-            "schema_version": 0,
-            "values": {
-              "allow_forwarded_traffic": true,
-              "allow_gateway_transit": true,
-              "allow_virtual_network_access": true,
-              "name": "peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
-              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope",
-              "resource_group_name": "root-id-1-connectivity-westeurope",
-              "timeouts": null,
-              "use_remote_gateways": false,
-              "virtual_network_name": "root-id-1-hub-westeurope"
             },
             "sensitive_values": {}
           },

--- a/tests/modules/test_003_add_mgmt_conn/baseline_values.json
+++ b/tests/modules/test_003_add_mgmt_conn/baseline_values.json
@@ -338,7 +338,10 @@
                 {
                   "connectivity": [
                     "tuple",
-                    []
+                    [
+                      "string",
+                      "string"
+                    ]
                   ]
                 }
               ],
@@ -859,7 +862,10 @@
                 {
                   "connectivity": [
                     "tuple",
-                    []
+                    [
+                      "string",
+                      "string"
+                    ]
                   ]
                 }
               ],
@@ -1649,7 +1655,10 @@
             ]
           },
           "azurerm_virtual_network_peering": {
-            "connectivity": []
+            "connectivity": [
+              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626"
+            ]
           },
           "azurerm_virtual_wan": {
             "virtual_wan": [
@@ -1969,7 +1978,10 @@
             "connectivity": []
           },
           "azurerm_virtual_network_peering": {
-            "connectivity": []
+            "connectivity": [
+              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+              "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626"
+            ]
           },
           "azurerm_virtual_wan": {
             "virtual_wan": []
@@ -3572,6 +3584,48 @@
               "tags": {},
               "vpn_client_configuration": []
             }
+          },
+          {
+            "address": "module.test_connectivity.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0\"]",
+            "mode": "managed",
+            "type": "azurerm_virtual_network_peering",
+            "name": "connectivity",
+            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+            "provider_name": "registry.terraform.io/hashicorp/azurerm",
+            "schema_version": 0,
+            "values": {
+              "allow_forwarded_traffic": true,
+              "allow_gateway_transit": true,
+              "allow_virtual_network_access": true,
+              "name": "peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope",
+              "resource_group_name": "root-id-1-connectivity-westeurope",
+              "timeouts": null,
+              "use_remote_gateways": false,
+              "virtual_network_name": "root-id-1-hub-westeurope"
+            },
+            "sensitive_values": {}
+          },
+          {
+            "address": "module.test_connectivity.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626\"]",
+            "mode": "managed",
+            "type": "azurerm_virtual_network_peering",
+            "name": "connectivity",
+            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
+            "provider_name": "registry.terraform.io/hashicorp/azurerm",
+            "schema_version": 0,
+            "values": {
+              "allow_forwarded_traffic": true,
+              "allow_gateway_transit": true,
+              "allow_virtual_network_access": true,
+              "name": "peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
+              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope",
+              "resource_group_name": "root-id-1-connectivity-northeurope",
+              "timeouts": null,
+              "use_remote_gateways": false,
+              "virtual_network_name": "root-id-1-hub-northeurope"
+            },
+            "sensitive_values": {}
           },
           {
             "address": "module.test_connectivity.azurerm_virtual_wan.virtual_wan[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity/providers/Microsoft.Network/virtualWans/root-id-1-vwan-northeurope\"]",
@@ -9118,6 +9172,48 @@
               "template_content": "{\"$schema\":\"https://schema.management.azure.com/schemas/2018-05-01/subscriptionDeploymentTemplate.json#\",\"contentVersion\":\"1.0.0.0\",\"outputs\":{\"telemetry\":{\"type\":\"String\",\"value\":\"For more information, see https://aka.ms/alz/tf/telemetry\"}},\"parameters\":{},\"resources\":[],\"variables\":{}}",
               "template_spec_version_id": null,
               "timeouts": null
+            },
+            "sensitive_values": {}
+          },
+          {
+            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0\"]",
+            "mode": "managed",
+            "type": "azurerm_virtual_network_peering",
+            "name": "connectivity",
+            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope/virtualNetworkPeerings/peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+            "provider_name": "registry.terraform.io/hashicorp/azurerm",
+            "schema_version": 0,
+            "values": {
+              "allow_forwarded_traffic": true,
+              "allow_gateway_transit": true,
+              "allow_virtual_network_access": true,
+              "name": "peering-f8bddac9-6d62-5e41-9c52-1bf7a4263cc0",
+              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-northeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-northeurope",
+              "resource_group_name": "root-id-1-connectivity-westeurope",
+              "timeouts": null,
+              "use_remote_gateways": false,
+              "virtual_network_name": "root-id-1-hub-westeurope"
+            },
+            "sensitive_values": {}
+          },
+          {
+            "address": "module.test_core.azurerm_virtual_network_peering.connectivity[\"/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626\"]",
+            "mode": "managed",
+            "type": "azurerm_virtual_network_peering",
+            "name": "connectivity",
+            "index": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope/virtualNetworkPeerings/peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
+            "provider_name": "registry.terraform.io/hashicorp/azurerm",
+            "schema_version": 0,
+            "values": {
+              "allow_forwarded_traffic": true,
+              "allow_gateway_transit": true,
+              "allow_virtual_network_access": true,
+              "name": "peering-32e4fb6d-8d44-5cd6-a7b6-aa17ca11b626",
+              "remote_virtual_network_id": "/subscriptions/fa2fa118-a60d-4700-9ef1-fa02beeaaea5/resourceGroups/root-id-1-connectivity-westeurope/providers/Microsoft.Network/virtualNetworks/root-id-1-hub-westeurope",
+              "resource_group_name": "root-id-1-connectivity-northeurope",
+              "timeouts": null,
+              "use_remote_gateways": false,
+              "virtual_network_name": "root-id-1-hub-northeurope"
             },
             "sensitive_values": {}
           },

--- a/tests/modules/test_003_add_mgmt_conn/main.tf
+++ b/tests/modules/test_003_add_mgmt_conn/main.tf
@@ -44,9 +44,6 @@ module "test_core" {
   deploy_connectivity_resources    = false
   configure_connectivity_resources = module.settings.connectivity.configure_connectivity_resources
   subscription_id_connectivity     = data.azurerm_client_config.connectivity.subscription_id
-
-  # Disable strict management group subscription association
-  strict_subscription_association = false
 }
 
 module "test_core_nested" {

--- a/variables.tf
+++ b/variables.tf
@@ -316,6 +316,7 @@ variable "configure_connectivity_resources" {
             })
             spoke_virtual_network_resource_ids      = list(string)
             enable_outbound_virtual_network_peering = bool
+            enable_hub_network_mesh_peering         = bool
           })
         })
       )
@@ -498,6 +499,7 @@ variable "configure_connectivity_resources" {
             }
             spoke_virtual_network_resource_ids      = []
             enable_outbound_virtual_network_peering = false
+            enable_hub_network_mesh_peering         = false
           }
         },
       ]


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Implements option to peer hub networks with new configuration:

`var.configure_connectivity_resources.settings.hub_networks[*].config.enable_hub_network_mesh_peering`

## This PR fixes/adds/changes/removes

1. fixes #258
2. Update docs for release v2.2.0
3. Adds docs for strict MG association non-idempotency

### Breaking Changes

1. Adds new attribute to complex object variable, therefore breaking change.

## Testing Evidence

Test with two hubs. Hub mesh peering enabled and also peering to one other spoke:

<img width="1089" alt="image" src="https://user-images.githubusercontent.com/16320656/181586455-f0ac4116-b99d-4b6d-8b7e-b9c174ea9a27.png">


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
