### PR TITLE
Add GitHub to ADO Sync Action

### DIFF
--- a/.github/actions-config/gh-ado-sync-config.json
+++ b/.github/actions-config/gh-ado-sync-config.json
@@ -1,0 +1,18 @@
+{
+  "log_level": "info",
+  "ado": {
+    "organization": "CSUSolEng",
+    "project": "Azure Landing Zones",
+    "wit": "GitHub Issue",
+    "states": {
+      "new": "New",
+      "closed": "Closed",
+      "reopened": "New",
+      "deleted": "Removed",
+      "active": "In Progress"
+    },
+    "bypassRules": true,
+    "autoCreate": true,
+    "areaPath": "Azure Landing Zones\\Terraform"
+  }
+}

--- a/.github/workflows/gh-ado-sync.yml
+++ b/.github/workflows/gh-ado-sync.yml
@@ -1,0 +1,24 @@
+name: Sync Issues with Azure DevOps Work Items
+
+on:
+  schedule:
+    - cron: '*/15 * * * *'
+  issues:
+    types: [opened, closed, deleted, reopened, edited, labeled, unlabeled, assigned, unassigned]
+  issue_comment:
+    types: [created]
+  workflow_dispatch: {}
+
+jobs:
+  alert:
+    runs-on: ubuntu-latest
+    name: Sync workflow
+    steps:       
+    - uses: actions/checkout@v3
+    - uses: a11smiles/GitSync@main
+      env:     
+        ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'
+        github_token: '${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}'
+        config_file: './.github/actions-config/gh-ado-sync-config.json'
+      with:
+        ado: ${{ secrets.ADO_MAPPINGS_HANDLES }}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Add GitHub to ADO Sync Action

**Secrets have already been added to repo 👍**

## This PR fixes/adds/changes/removes

1. Add GitHub to ADO Sync Action

### Breaking Changes

None

## Testing Evidence

Linting will suffice and already working in ALZ-Bicep repo and ADO

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
