### PR TITLE
Add Workflow Restriction to GH/ADO Sync

### DIFF
--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -7,11 +7,6 @@ name: Code Review
 
 # yamllint disable-line rule:truthy
 on:
-  push:
-    branches-ignore:
-      - main
-      - patch-library
-      - release/**
   pull_request:
     branches:
       - main

--- a/.github/workflows/gh-ado-sync.yml
+++ b/.github/workflows/gh-ado-sync.yml
@@ -13,7 +13,7 @@ jobs:
   alert:
     runs-on: ubuntu-latest
     name: Sync workflow
-    if: github.repository == 'Azure/terraform-azurerm-caf-enterprise-scale' || github.event_name == 'workflow_dispatch'
+    if: github.repository == 'Azure/terraform-azurerm-caf-enterprise-scale'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/gh-ado-sync.yml
+++ b/.github/workflows/gh-ado-sync.yml
@@ -13,7 +13,7 @@ jobs:
   alert:
     runs-on: ubuntu-latest
     name: Sync workflow
-    if: github.repository == 'Azure/terraform-azurerm-caf-enterprise-scale'
+    if: github.repository == 'Azure/terraform-azurerm-caf-enterprise-scale' || github.event_name == 'workflow_dispatch'
 
     steps:
       - name: Checkout code

--- a/.github/workflows/gh-ado-sync.yml
+++ b/.github/workflows/gh-ado-sync.yml
@@ -13,6 +13,7 @@ jobs:
   alert:
     runs-on: ubuntu-latest
     name: Sync workflow
+    if: github.repository == 'Azure/terraform-azurerm-caf-enterprise-scale'
 
     steps:
       - name: Checkout code


### PR DESCRIPTION


<h2 id=overviewsummary>Overview/Summary </h2>
<p>Add Workflow Restriction to GH/ADO Sync to only allow workflow to run on this repository only and not forks. </p>
<h2 id=thisprfixesaddschangesremoves>This PR fixes/adds/changes/removes </h2>
<ol>
<li>Add Workflow Restriction to GH/ADO Sync to only allow workflow to run on this repository only and not forks. </li>
</ol>
<h3 id=breakingchanges>Breaking Changes </h3>
<p>None </p>
<h2 id=testingevidence>Testing Evidence </h2>
<p>Linting will suffice </p>
<h2 id=aspartofthispullrequestihave>As part of this Pull Request I have </h2>
<ul>
<li>[x] Checked for duplicate <a href="https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls">Pull Requests</a> </li>
<li>[x] Associated it with relevant <a href="https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues">issues</a>, for tracking and closure. </li>
<li>[x] Ensured my code/branch is up-to-date with the latest changes in the <code>main</code> <a href="https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main">branch</a> </li>
<li>[ ] Performed testing and provided evidence. </li>
<li>[ ] Updated relevant and associated documentation. </li>
<li>[ ] Updated the <a href="https://github.com/Azure/Enterprise-Scale/wiki/Whats-new">&quot;What's New?&quot;</a> wiki page (located in the <a href="https://github.com/Azure/Enterprise-Scale">Enterprise-Scale repo</a> in the directory: <code>/docs/wiki/whats-new.md</code>) </li>
</ul>