### PR TITLE
Missing required property connectivity settings

### DIFF
--- a/docs/wiki/[Examples]-Deploy-Connectivity-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Connectivity-Resources-With-Custom-Settings.md
@@ -215,6 +215,7 @@ locals {
             }
             spoke_virtual_network_resource_ids      = []
             enable_outbound_virtual_network_peering = true
+            enable_hub_network_mesh_peering         = false
           }
         },
         {
@@ -328,6 +329,7 @@ locals {
           private_dns_zones                                      = []
           enable_private_dns_zone_virtual_network_link_on_hubs   = true
           enable_private_dns_zone_virtual_network_link_on_spokes = true
+          enable_hub_network_mesh_peering                        = false
         }
       }
     }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. Missing required property connectivity settings. **enable_hub_network_mesh_peering** is a required property for the module to work but is not defined in the example. 
Addressing error
![image](https://user-images.githubusercontent.com/17753252/197554408-c202293e-6223-4382-87dd-784976ef7be2.png)


### Breaking Changes

1. *Replace me*
2. *Replace me*

## Testing Evidence
No errors were displayed when running 'Terraform plan' after adding the required property. 
![image](https://user-images.githubusercontent.com/17753252/197580198-debf8518-7302-41fc-8d45-2cccad350542.png)

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [ x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x ] Performed testing and provided evidence.
- [x ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
