### PR TITLE
Pin ADO sync to `v1.1.4`

### DIFF
--- a/.github/workflows/gh-ado-sync.yml
+++ b/.github/workflows/gh-ado-sync.yml
@@ -21,7 +21,7 @@ jobs:
           fetch-depth: 0
 
       - name: GitHub/ADO Sync
-        uses: a11smiles/GitSync@main
+        uses: a11smiles/GitSync@v1.1.4
         env:
           ado_token: '${{ secrets.ADO_PERSONAL_ACCESS_TOKEN }}'
           config_file: './.github/actions-config/gh-ado-sync-config.json'


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR reverts ADO sync to `v1.1.4` on a pinned version as 'main' appears to be not working currently:

```shell
Run a[1](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/actions/runs/3376326929/jobs/5603916329#step:3:1)1smiles/GitSync@main
JSON configuration file loaded.
Setting logLevel to info...
TypeError: Cannot read properties of undefined (reading 'startsWith')
    at GitSync.run (/home/runner/work/_actions/a11smiles/GitSync/main/gitsync.js:28:3[7](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/actions/runs/3376326929/jobs/5603916329#step:3:8))
    at Object.<anonymous> (/home/runner/work/_actions/a11smiles/GitSync/main/index.js:4:6)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:9[8](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/actions/runs/3376326929/jobs/5603916329#step:3:9)1:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:[12](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/actions/runs/3376326929/jobs/5603916329#step:3:13))
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:[17](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/actions/runs/3376326929/jobs/5603916329#step:3:18):47
```

## This PR fixes/adds/changes/removes

1. The error above

### Breaking Changes

n/a

## Testing Evidence

TBC post merge due to action limitations

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
