### PR TITLE
Bring back azure_synapse_analytics_sqlserver

### DIFF
--- a/docs/wiki/[Examples]-Deploy-Connectivity-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Connectivity-Resources-With-Custom-Settings.md
@@ -327,6 +327,7 @@ locals {
             azure_sql_database_sqlserver         = true
             azure_synapse_analytics_dev          = true
             azure_synapse_analytics_sql          = true
+            azure_synapse_analytics_sqlserver    = true
             azure_synapse_studio                 = true
             azure_web_apps_sites                 = true
             azure_web_apps_static_sites          = true


### PR DESCRIPTION
this variable is mandatory apparently, last commit removed it azure_synapse_analytics_sqlserver    = true

<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. *Replace me*
2. *Replace me*
3. *Replace me*

### Breaking Changes

1. *Replace me*
2. *Replace me*

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
