### PR TITLE
Fixed revoke_certificate variable iterator

### DIFF
--- a/resources.connectivity.tf
+++ b/resources.connectivity.tf
@@ -194,8 +194,8 @@ resource "azurerm_virtual_network_gateway" "connectivity" {
       dynamic "revoked_certificate" {
         for_each = try(vpn_client_configuration.value["revoked_certificate"], local.empty_list)
         content {
-          name       = root_certificate.value["name"]
-          thumbprint = root_certificate.value["thumbprint"]
+          name       = revoked_certificate.value["name"]
+          thumbprint = revoked_certificate.value["thumbprint"]
         }
       }
     }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Fixes https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/508

This fixes the issue when using the Connectivity resource  `hub_networks.virtual_network_gateway.advanced_vpn_settings.vpn_client_configuration` and providing a `revoke_certificate` it would pass validation but when applying the plan it would fail to find the value of the resources provided. 

## This PR fixes/adds/changes/removes

1. Fixes interaction value for `revoke_certificate`

### Breaking Changes

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
