### PR TITLE
Update firewall configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ This allows customers to address concerns around managing large state files, or 
 
 ## Terraform versions
 
-This module has been tested using Terraform `0.15.1` and AzureRM Provider `3.18.0` as a baseline, and various versions to up the latest at time of release.
+This module has been tested using Terraform `0.15.1` and AzureRM Provider `3.19.0` as a baseline, and various versions to up the latest at time of release.
 In some cases, individual versions of the AzureRM provider may cause errors.
 If this happens, we advise upgrading to the latest version and checking our [troubleshooting][wiki_troubleshooting] guide before [raising an issue](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues).
 
@@ -61,7 +61,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[Examples]-Deploy-Connectivity-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Connectivity-Resources-With-Custom-Settings.md
@@ -73,7 +73,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[Examples]-Deploy-Connectivity-Resources.md
+++ b/docs/wiki/[Examples]-Deploy-Connectivity-Resources.md
@@ -51,7 +51,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[Examples]-Deploy-Custom-Landing-Zone-Archetypes.md
+++ b/docs/wiki/[Examples]-Deploy-Custom-Landing-Zone-Archetypes.md
@@ -44,7 +44,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[Examples]-Deploy-Default-Configuration.md
+++ b/docs/wiki/[Examples]-Deploy-Default-Configuration.md
@@ -26,7 +26,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[Examples]-Deploy-Demo-Landing-Zone-Archetypes.md
+++ b/docs/wiki/[Examples]-Deploy-Demo-Landing-Zone-Archetypes.md
@@ -33,7 +33,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[Examples]-Deploy-Identity-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Identity-Resources-With-Custom-Settings.md
@@ -47,7 +47,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[Examples]-Deploy-Identity-Resources.md
+++ b/docs/wiki/[Examples]-Deploy-Identity-Resources.md
@@ -41,7 +41,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[Examples]-Deploy-Management-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Management-Resources-With-Custom-Settings.md
@@ -55,7 +55,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[Examples]-Deploy-Management-Resources.md
+++ b/docs/wiki/[Examples]-Deploy-Management-Resources.md
@@ -41,7 +41,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[Examples]-Deploy-Using-Module-Nesting.md
+++ b/docs/wiki/[Examples]-Deploy-Using-Module-Nesting.md
@@ -84,7 +84,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources-With-Custom-Settings.md
@@ -71,7 +71,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources.md
+++ b/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources.md
@@ -58,7 +58,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[Examples]-Expand-built-in-archetype-definitions.md
+++ b/docs/wiki/[Examples]-Expand-built-in-archetype-definitions.md
@@ -78,7 +78,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[Examples]-Override-Module-Role-Assignments.md
+++ b/docs/wiki/[Examples]-Override-Module-Role-Assignments.md
@@ -52,7 +52,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }

--- a/docs/wiki/[User-Guide]-Getting-Started.md
+++ b/docs/wiki/[User-Guide]-Getting-Started.md
@@ -3,7 +3,7 @@
 
 Before getting started with this module, please take note of the following considerations:
 
-1. This module requires a minimum `azurerm` provider version of `3.18.0`.
+1. This module requires a minimum `azurerm` provider version of `3.19.0`.
 
 1. This module requires a minimum Terraform version `0.15.1`.
 

--- a/docs/wiki/[User-Guide]-Provider-Configuration.md
+++ b/docs/wiki/[User-Guide]-Provider-Configuration.md
@@ -54,7 +54,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 }
@@ -112,7 +112,7 @@ terraform {
   required_providers {
     azurerm = {
       source                = "hashicorp/azurerm"
-      version               = ">= 3.18.0"
+      version               = ">= 3.19.0"
       configuration_aliases = [
         azurerm.connectivity,
         azurerm.management,

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -945,10 +945,12 @@ locals {
               }
             ]
           )
-          identity            = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].identity, local.empty_list)
-          insights            = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].insights, local.empty_list)
-          intrusion_detection = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].intrusion_detection, local.empty_list)
-          tags                = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].tags, null)
+          identity             = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].identity, local.empty_list)
+          insights             = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].insights, local.empty_list)
+          intrusion_detection  = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].intrusion_detection, local.empty_list)
+          tls_certificate      = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].tls_certificate, local.empty_list)
+          sql_redirect_allowed = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].sql_redirect_allowed, null)
+          tags                 = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].tags, null)
         }
         # Child resource definition attributes
         azurerm_public_ip = (

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -774,6 +774,7 @@ locals {
 # Configuration settings for resource type:
 #  - azurerm_firewall
 # For VWAN, VPN gateway is required for Security Partner Provider integration
+# For zonal deployments, the public IP must be either single-zone, or all-zones (see #447 for more information)
 locals {
   azfw_name = {
     for location in local.hub_network_locations :
@@ -838,6 +839,18 @@ locals {
     for location in local.hub_network_locations :
     location =>
     "${local.azfw_pip_resource_id_prefix[location]}/${local.azfw_pip_name[location]}"
+  }
+  azfw_pip_zones = {
+    for location in local.hub_network_locations :
+    location =>
+    try(
+      local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].zones,
+      length(local.azfw_zones[location]) == 1 ?
+      local.azfw_zones[location] :
+      length(local.azfw_zones[location]) >= 2 ?
+      ["1", "2", "3"] :
+      null
+    )
   }
   virtual_hub_azfw_name = {
     for location in local.virtual_hub_locations :
@@ -965,6 +978,7 @@ locals {
             name                    = local.azfw_pip_name[location]
             resource_group_name     = local.resource_group_names_by_scope_and_location["connectivity"][location]
             location                = location
+            zones                   = local.azfw_pip_zones[location]
             sku                     = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].sku, "Standard")
             allocation_method       = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].allocation_method, "Static")
             ip_version              = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].ip_version, null)
@@ -974,10 +988,6 @@ locals {
             public_ip_prefix_id     = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].public_ip_prefix_id, null)
             ip_tags                 = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].ip_tags, null)
             tags                    = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].tags, local.tags)
-            zones = try(
-              local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].zones,
-              local.azfw_zones[location]
-            )
           }]
         )
       }

--- a/modules/role_assignments_for_policy/terraform.tf
+++ b/modules/role_assignments_for_policy/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
     }
   }
 

--- a/resources.connectivity.tf
+++ b/resources.connectivity.tf
@@ -253,6 +253,7 @@ resource "azurerm_firewall_policy" "connectivity" {
   sku                      = each.value.template.sku
   tags                     = each.value.template.tags
   threat_intelligence_mode = each.value.template.threat_intelligence_mode # "Alert", "Deny" or "Off". Defaults to "Alert"
+  sql_redirect_allowed     = each.value.template.sql_redirect_allowed
 
   # Dynamic configuration blocks
   dynamic "dns" {
@@ -331,6 +332,15 @@ resource "azurerm_firewall_policy" "connectivity" {
       # Optional attributes
       fqdns        = lookup(threat_intelligence_allowlist.value, "fqdns", null)
       ip_addresses = lookup(threat_intelligence_allowlist.value, "ip_addresses", null)
+    }
+  }
+
+  dynamic "tls_certificate" {
+    for_each = each.value.template.tls_certificate
+    content {
+      # Mandatory attributes
+      key_vault_secret_id = tls_certificate.value["key_vault_secret_id"]
+      name                = tls_certificate.value["name"]
     }
   }
 

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = ">= 3.18.0"
+      version = ">= 3.19.0"
       configuration_aliases = [
         azurerm.connectivity,
         azurerm.management,

--- a/tests/README.md
+++ b/tests/README.md
@@ -153,7 +153,7 @@ The current strategy consists of running tests against the following version com
   - Latest `1.0.x` version
   - Latest `1.1.x` version
 - Azure provider for Terraform versions:
-  - Minimum version supported by the module (`v3.18.0`)
+  - Minimum version supported by the module (`v3.19.0`)
   - Latest version
 
 The latest versions are determined programmatically by querying the publisher APIs.

--- a/tests/modules/settings/settings.connectivity.tf
+++ b/tests/modules/settings/settings.connectivity.tf
@@ -43,7 +43,7 @@ locals {
                 availability_zones = {
                   zone_1 = true
                   zone_2 = true
-                  zone_3 = true
+                  zone_3 = false
                 }
               }
             }

--- a/tests/modules/settings/settings.connectivity.tf
+++ b/tests/modules/settings/settings.connectivity.tf
@@ -269,6 +269,16 @@ locals {
 
     location = null
     tags     = null
-    advanced = null
+    advanced = {
+      custom_settings_by_resource_type = {
+        azurerm_firewall_policy = {
+          connectivity = {
+            (var.primary_location) = {
+              sql_redirect_allowed = false
+            }
+          }
+        }
+      }
+    }
   }
 }

--- a/tests/modules/test_001_baseline/terraform.tf
+++ b/tests/modules/test_001_baseline/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.18.0"
+      version = "3.19.0"
       configuration_aliases = [
         azurerm.connectivity,
         azurerm.management,

--- a/tests/modules/test_002_add_custom_core/terraform.tf
+++ b/tests/modules/test_002_add_custom_core/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.18.0"
+      version = "3.19.0"
       configuration_aliases = [
         azurerm.connectivity,
         azurerm.management,

--- a/tests/modules/test_003_add_mgmt_conn/baseline_values.json
+++ b/tests/modules/test_003_add_mgmt_conn/baseline_values.json
@@ -2271,8 +2271,7 @@
               "virtual_hub": [],
               "zones": [
                 "1",
-                "2",
-                "3"
+                "2"
               ]
             },
             "sensitive_values": {
@@ -2283,7 +2282,6 @@
               "tags": {},
               "virtual_hub": [],
               "zones": [
-                false,
                 false,
                 false
               ]
@@ -2362,6 +2360,7 @@
               "private_ip_ranges": null,
               "resource_group_name": "root-id-1-connectivity-northeurope",
               "sku": "Standard",
+              "sql_redirect_allowed": false,
               "tags": null,
               "threat_intelligence_allowlist": [],
               "threat_intelligence_mode": "Alert",
@@ -2406,6 +2405,7 @@
               "private_ip_ranges": null,
               "resource_group_name": "root-id-1-connectivity",
               "sku": "Standard",
+              "sql_redirect_allowed": null,
               "tags": null,
               "threat_intelligence_allowlist": [],
               "threat_intelligence_mode": "Alert",
@@ -10494,6 +10494,7 @@
             "schema_version": 0,
             "values": {
               "identity": [],
+              "local_authentication_enabled": true,
               "location": "northeurope",
               "name": "root-id-1-automation",
               "public_network_access_enabled": true,
@@ -10505,7 +10506,9 @@
               "timeouts": null
             },
             "sensitive_values": {
+              "encryption": [],
               "identity": [],
+              "private_endpoint_connection": [],
               "tags": {}
             }
           },
@@ -10799,6 +10802,7 @@
             "provider_name": "registry.terraform.io/hashicorp/azurerm",
             "schema_version": 2,
             "values": {
+              "cmk_for_query_forced": null,
               "daily_quota_gb": -1,
               "internet_ingestion_enabled": true,
               "internet_query_enabled": true,

--- a/tests/modules/test_003_add_mgmt_conn/terraform.tf
+++ b/tests/modules/test_003_add_mgmt_conn/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.18.0"
+      version = "3.19.0"
       configuration_aliases = [
         azurerm.connectivity,
         azurerm.management,

--- a/tests/opa/policy/readme.md
+++ b/tests/opa/policy/readme.md
@@ -1,6 +1,6 @@
 # Test suite for Azure landing zones Terraform module
 
-The Azure landing zones Terraform module is able to deploy different groups of resources depending on the selected options. The module also requires a minimum AzureRM provider version of `v3.18.0` and it is compatible with a selection of Terraform versions, as described in the module's official wiki page.
+The Azure landing zones Terraform module is able to deploy different groups of resources depending on the selected options. The module also requires a minimum AzureRM provider version of `v3.19.0` and it is compatible with a selection of Terraform versions, as described in the module's official wiki page.
 
 [Open Policy Agent](https://www.openpolicyagent.org/docs/latest) is an open source, general-purpose policy engine that unifies policy enforcement across the stack.
 

--- a/tests/scripts/azp-strategy.ps1
+++ b/tests/scripts/azp-strategy.ps1
@@ -53,11 +53,11 @@ $terraformVersionsCount = $terraformVersions.Count
 
 #######################################
 # Terraform AzureRM Provider Versions
-# - Base Version: (3.18.0)
+# - Base Version: (3.19.0)
 # - Latest Versions: (latest 1)
 #######################################
 
-$azurermProviderVersionBase = "3.18.0"
+$azurermProviderVersionBase = "3.19.0"
 $azurermProviderVersionLatest = (Invoke-RestMethod -Method Get -Uri $azurermProviderUrl).version
 
 #######################################


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR updates the firewall configuration options to fix the issues below

## This PR fixes/adds/changes/removes

1. Fix #513 
2. Fix #447 

> **NOTE:** This PR introduces the fix for #513 via the `advanced` block. We plan to move this as part of refactoring the module to support `optional()` types within the input variables.

### Breaking Changes

1. Update to the required minimum provider version from `v3.18.0` to `v3.19.0` to allow inclusion of added `sql_redirect_allowed` attribute on the `azurerm_firewall_policy` resource type

## Testing Evidence

Evidence for #447 provided within the test suite and visible within `baseline_values.json`

For #513, we have also added `sql_redirect_allowed` which is set using the same logic which is tried and tested. This has been added via the `advanced` block to show that this setting is taking effect, but we don't currently have a way to test the full functionality of this optional setting.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["What's New?"](https://github.com/Azure/Enterprise-Scale/wiki/Whats-new) wiki page (located in the [Enterprise-Scale repo](https://github.com/Azure/Enterprise-Scale) in the directory: `/docs/wiki/whats-new.md`)
