### PR TITLE
Add Kubernetes namespace for Arc DNS

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,7 +6,7 @@ The `v3.1.0` release includes a number of minor updates as listed below.
 
 ### New features
 
-- Added `privatelink.kubernetesconfiguration.azure.com` to list of private DNS zones for ``
+- Added `privatelink.kubernetesconfiguration.azure.com` to list of private DNS zones for `azure_arc` private endpoints
 
 ### Fixed issues
 

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -1,51 +1,21 @@
-# [v3.0.0] Simplify inputs with `optional()` support and more
+# [v3.1.0] Release title TBC
 
 ## Overview
 
-The `v3.0.0` release marks an important update to the module, aimed primarily at reducing code changes needed when upgrading to latest releases.
-Previously, any change to the schema of input variables with complex object types would result in a breaking change if not updated in the customer code.
-This has been made possible with the GA release of `optional()` types in Terraform v1.3.0.
-
-As a result of this change and the required fix for [issue #31844](https://github.com/hashicorp/terraform/issues/31844), we have increased the minimum supported Terraform version to `v1.3.1`.
-
-To support other changes (as listed below), we have also bumped the minimum supported `azurerm` provider version to `v3.19.0`.
+The `v3.1.0` release includes a number of minor updates as listed below.
 
 ### New features
 
-- Added documentation for how to set parameters for Policy Assignments
-- Updated GitHub Super-Linter to `v4.9.7` for static code analysis
-- Updated the list of private DNS zones created by the module for private endpoints
-- Removed deprecated policies for Arc monitoring (now included within VM monitoring built-in initiative)
-- Added ability to set `sql_redirect_allowed` and `tls_certificate` properties on Azure Firewall policies
-- Update logic for Azure Firewall public IPs to ensure correct availability zone mapping when only 2 zones are specified
-- Added support for `optional()` types in input variables
-- Updated policies with the latest fixes from the upstream [Azure/Enterprise-Scale](https://github.com/Azure/Enterprise-Scale) repository
-- Updated tag evaluation for connectivity and management resources, so `default_tags` are now merged with scope-specific tags
-- Updated the module upgrade guidance
-- Updated `Deny-Public-IP` policy assignment to use the built-in policy for `Not allowed resource types`
+- Added `privatelink.kubernetesconfiguration.azure.com` to list of private DNS zones for ``
 
 ### Fixed issues
 
-- Fix [#445](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/445) (azurerm v4 compatibility)
-- Fix [#359](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/359) (Specifying parameters in policy assignment loses Log Analytics ID)
-- Fix [#186](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/186) (Policies incompatible with Terraform)
-- Fix [#444](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/444) (Error received when running custom network connectivity deployment)
-- Fix [#508](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/508) (Bug Report: Advanced VPN revoke_certifcate fails to apply)
-- Fix [#513](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/513) (Feature Request: Azure Firewall: Specify TLS Certificate Location in Azure Keyvault)
-- Fix [#447](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/447) (Azure Firewall - Availability Zones)
-- Fix [#524](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/524) (Missing private DNS zone for private endpoint - Azure Data Health Data Services)
-- Fix [#521](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/521) (Feature Request - ExpressRoute Gateway VPN_Type is Hardcoded, parameterise.)
+- Fix [#482](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/445) (Review and update private DNS zones for private endpoint #482)
 
 ### Breaking changes
 
-- :warning: Updated the minimum supported Terraform version to `0.15.1`
-- :warning: Updated the minimum supported `azurerm` provider version to `3.0.2`
-- :warning: Terraform will replace the `Deny-Public-IP` policy assignment, resulting in loss of compliance history
-
-> **IMPORTANT:** Please also carefully review the planned changes following an upgrade, as the introduction of `optional()` settings may result in unexpected changes from your current configuration where recommended new features are enabled by default.
+n/a
 
 ## For more information
 
-Please refer to the [Upgrade from v2.4.1 to v3.0.0](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/wiki/%5BUser-Guide%5D-Upgrade-from-v2.4.1-to-v3.0.0) page on our Wiki.
-
-**Full Changelog**: [v2.4.1...v3.0.0](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/compare/v2.4.1...v3.0.0)
+**Full Changelog**: [v3.0.0...v3.1.0](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/compare/v3.0.0...v3.1.0)

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1297,7 +1297,7 @@ locals {
   lookup_private_link_dns_zone_by_service = {
     azure_api_management                 = ["privatelink.azure-api.net", "privatelink.developer.azure-api.net"]
     azure_app_configuration_stores       = ["privatelink.azconfig.io"]
-    azure_arc                            = ["privatelink.his.arc.azure.com", "privatelink.guestconfiguration.azure.com"]
+    azure_arc                            = ["privatelink.his.arc.azure.com", "privatelink.guestconfiguration.azure.com", "privatelink.kubernetesconfiguration.azure.com"]
     azure_automation_dscandhybridworker  = ["privatelink.azure-automation.net"]
     azure_automation_webhook             = ["privatelink.azure-automation.net"]
     azure_batch_account                  = ["privatelink.batch.azure.com"]


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR adds a missing `privatelink.kubernetesconfiguration.azure.com` namespace to the private DNS zones for Azure Arc.

## This PR fixes/adds/changes/removes

1. Missed in the fix for #482

### Breaking Changes

None

## Testing Evidence

See unit tests

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["RELEASE"](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues) page with details needed for when this code change is released.
