### PR TITLE
Update MCSB policy assignment

### DIFF
--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_asc_monitoring.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_asc_monitoring.tmpl.json
@@ -3,8 +3,8 @@
   "type": "Microsoft.Authorization/policyAssignments",
   "apiVersion": "2019-09-01",
   "properties": {
-    "description": "Enable Monitoring in Azure Security Center.",
-    "displayName": "Enable Monitoring in Azure Security Center",
+    "description": "Microsoft Cloud Security Benchmark policy initiative.",
+    "displayName": "Microsoft Cloud Security Benchmark",
     "notScopes": [],
     "parameters": {},
     "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8",

--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_asc_monitoring.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deploy_asc_monitoring.tmpl.json
@@ -6,74 +6,7 @@
     "description": "Enable Monitoring in Azure Security Center.",
     "displayName": "Enable Monitoring in Azure Security Center",
     "notScopes": [],
-    "parameters": {
-      "aadAuthenticationInSqlServerMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "diskEncryptionMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "encryptionOfAutomationAccountMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "identityDesignateLessThanOwnersMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "identityDesignateMoreThanOneOwnerMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "identityEnableMFAForWritePermissionsMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "identityRemoveDeprecatedAccountMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "identityRemoveExternalAccountWithReadPermissionsMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "identityRemoveExternalAccountWithWritePermissionsMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "jitNetworkAccessMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "networkSecurityGroupsOnSubnetsMonitoringEffect": {
-        "value": "AuditIfNotExists"
-      },
-      "sqlDbEncryptionMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "sqlManagedInstanceAdvancedDataSecurityEmailAdminsMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "sqlManagedInstanceAdvancedDataSecurityEmailsMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "sqlServerAdvancedDataSecurityEmailAdminsMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "sqlServerAdvancedDataSecurityMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "systemUpdatesMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "useRbacRulesMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "vmssSystemUpdatesMonitoringEffect": {
-        "value": "Disabled"
-      },
-      "windowsDefenderExploitGuardMonitoringEffect": {
-        "value": "Disabled"
-      }
-    },
+    "parameters": {},
     "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8",
     "scope": "${current_scope_resource_id}",
     "enforcementMode": null

--- a/tests/modules/test_001_baseline/baseline_values.json
+++ b/tests/modules/test_001_baseline/baseline_values.json
@@ -1516,8 +1516,8 @@
             "provider_name": "registry.terraform.io/hashicorp/azurerm",
             "schema_version": 0,
             "values": {
-              "description": "Enable Monitoring in Azure Security Center.",
-              "display_name": "Enable Monitoring in Azure Security Center",
+              "description": "Microsoft Cloud Security Benchmark policy initiative.",
+              "display_name": "Microsoft Cloud Security Benchmark",
               "enforce": true,
               "identity": [],
               "location": "northeurope",
@@ -1525,7 +1525,7 @@
               "name": "Deploy-ASC-Monitoring",
               "non_compliance_message": [],
               "not_scopes": [],
-              "parameters": "{\"aadAuthenticationInSqlServerMonitoringEffect\":{\"value\":\"Disabled\"},\"diskEncryptionMonitoringEffect\":{\"value\":\"Disabled\"},\"encryptionOfAutomationAccountMonitoringEffect\":{\"value\":\"Disabled\"},\"identityDesignateLessThanOwnersMonitoringEffect\":{\"value\":\"Disabled\"},\"identityDesignateMoreThanOneOwnerMonitoringEffect\":{\"value\":\"Disabled\"},\"identityEnableMFAForWritePermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveDeprecatedAccountMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveExternalAccountWithReadPermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveExternalAccountWithWritePermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"jitNetworkAccessMonitoringEffect\":{\"value\":\"Disabled\"},\"networkSecurityGroupsOnSubnetsMonitoringEffect\":{\"value\":\"AuditIfNotExists\"},\"sqlDbEncryptionMonitoringEffect\":{\"value\":\"Disabled\"},\"sqlManagedInstanceAdvancedDataSecurityEmailAdminsMonitoringEffect\":{\"value\":\"Disabled\"},\"sqlManagedInstanceAdvancedDataSecurityEmailsMonitoringEffect\":{\"value\":\"Disabled\"},\"sqlServerAdvancedDataSecurityEmailAdminsMonitoringEffect\":{\"value\":\"Disabled\"},\"sqlServerAdvancedDataSecurityMonitoringEffect\":{\"value\":\"Disabled\"},\"systemUpdatesMonitoringEffect\":{\"value\":\"Disabled\"},\"useRbacRulesMonitoringEffect\":{\"value\":\"Disabled\"},\"vmssSystemUpdatesMonitoringEffect\":{\"value\":\"Disabled\"},\"windowsDefenderExploitGuardMonitoringEffect\":{\"value\":\"Disabled\"}}",
+              "parameters": null,
               "policy_definition_id": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8",
               "timeouts": null
             },

--- a/tests/modules/test_002_add_custom_core/baseline_values.json
+++ b/tests/modules/test_002_add_custom_core/baseline_values.json
@@ -2323,8 +2323,8 @@
             "provider_name": "registry.terraform.io/hashicorp/azurerm",
             "schema_version": 0,
             "values": {
-              "description": "Enable Monitoring in Azure Security Center.",
-              "display_name": "Enable Monitoring in Azure Security Center",
+              "description": "Microsoft Cloud Security Benchmark policy initiative.",
+              "display_name": "Microsoft Cloud Security Benchmark",
               "enforce": true,
               "identity": [],
               "location": "northeurope",
@@ -2332,7 +2332,7 @@
               "name": "Deploy-ASC-Monitoring",
               "non_compliance_message": [],
               "not_scopes": [],
-              "parameters": "{\"aadAuthenticationInSqlServerMonitoringEffect\":{\"value\":\"Disabled\"},\"diskEncryptionMonitoringEffect\":{\"value\":\"Disabled\"},\"encryptionOfAutomationAccountMonitoringEffect\":{\"value\":\"Disabled\"},\"identityDesignateLessThanOwnersMonitoringEffect\":{\"value\":\"Disabled\"},\"identityDesignateMoreThanOneOwnerMonitoringEffect\":{\"value\":\"Disabled\"},\"identityEnableMFAForWritePermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveDeprecatedAccountMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveExternalAccountWithReadPermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveExternalAccountWithWritePermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"jitNetworkAccessMonitoringEffect\":{\"value\":\"Disabled\"},\"networkSecurityGroupsOnSubnetsMonitoringEffect\":{\"value\":\"AuditIfNotExists\"},\"sqlDbEncryptionMonitoringEffect\":{\"value\":\"Disabled\"},\"sqlManagedInstanceAdvancedDataSecurityEmailAdminsMonitoringEffect\":{\"value\":\"Disabled\"},\"sqlManagedInstanceAdvancedDataSecurityEmailsMonitoringEffect\":{\"value\":\"Disabled\"},\"sqlServerAdvancedDataSecurityEmailAdminsMonitoringEffect\":{\"value\":\"Disabled\"},\"sqlServerAdvancedDataSecurityMonitoringEffect\":{\"value\":\"Disabled\"},\"systemUpdatesMonitoringEffect\":{\"value\":\"Disabled\"},\"useRbacRulesMonitoringEffect\":{\"value\":\"Disabled\"},\"vmssSystemUpdatesMonitoringEffect\":{\"value\":\"Disabled\"},\"windowsDefenderExploitGuardMonitoringEffect\":{\"value\":\"Disabled\"}}",
+              "parameters": null,
               "policy_definition_id": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8",
               "timeouts": null
             },

--- a/tests/modules/test_003_add_mgmt_conn/baseline_values.json
+++ b/tests/modules/test_003_add_mgmt_conn/baseline_values.json
@@ -5313,8 +5313,8 @@
             "provider_name": "registry.terraform.io/hashicorp/azurerm",
             "schema_version": 0,
             "values": {
-              "description": "Enable Monitoring in Azure Security Center.",
-              "display_name": "Enable Monitoring in Azure Security Center",
+              "description": "Microsoft Cloud Security Benchmark policy initiative.",
+              "display_name": "Microsoft Cloud Security Benchmark",
               "enforce": true,
               "identity": [],
               "location": "northeurope",
@@ -5322,7 +5322,7 @@
               "name": "Deploy-ASC-Monitoring",
               "non_compliance_message": [],
               "not_scopes": [],
-              "parameters": "{\"aadAuthenticationInSqlServerMonitoringEffect\":{\"value\":\"Disabled\"},\"diskEncryptionMonitoringEffect\":{\"value\":\"Disabled\"},\"encryptionOfAutomationAccountMonitoringEffect\":{\"value\":\"Disabled\"},\"identityDesignateLessThanOwnersMonitoringEffect\":{\"value\":\"Disabled\"},\"identityDesignateMoreThanOneOwnerMonitoringEffect\":{\"value\":\"Disabled\"},\"identityEnableMFAForWritePermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveDeprecatedAccountMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveDeprecatedAccountWithOwnerPermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveExternalAccountWithOwnerPermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveExternalAccountWithReadPermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"identityRemoveExternalAccountWithWritePermissionsMonitoringEffect\":{\"value\":\"Disabled\"},\"jitNetworkAccessMonitoringEffect\":{\"value\":\"Disabled\"},\"networkSecurityGroupsOnSubnetsMonitoringEffect\":{\"value\":\"AuditIfNotExists\"},\"sqlDbEncryptionMonitoringEffect\":{\"value\":\"Disabled\"},\"sqlManagedInstanceAdvancedDataSecurityEmailAdminsMonitoringEffect\":{\"value\":\"Disabled\"},\"sqlManagedInstanceAdvancedDataSecurityEmailsMonitoringEffect\":{\"value\":\"Disabled\"},\"sqlServerAdvancedDataSecurityEmailAdminsMonitoringEffect\":{\"value\":\"Disabled\"},\"sqlServerAdvancedDataSecurityMonitoringEffect\":{\"value\":\"Disabled\"},\"systemUpdatesMonitoringEffect\":{\"value\":\"Disabled\"},\"useRbacRulesMonitoringEffect\":{\"value\":\"Disabled\"},\"vmssSystemUpdatesMonitoringEffect\":{\"value\":\"Disabled\"},\"windowsDefenderExploitGuardMonitoringEffect\":{\"value\":\"Disabled\"}}",
+              "parameters": null,
               "policy_definition_id": "/providers/Microsoft.Authorization/policySetDefinitions/1f3afdf9-d0c9-4c3d-847f-89da613e70a8",
               "timeouts": null
             },


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Cleanup of the Microsoft Cloud Security Benchmark initiative assignment parameters to align with all RIs. These parameters were set to disable a handful of policies in the initiative inconsistently across RIs and have now reverted to defaults.
Also updated assignment display name and description to align across RIs.

## This PR fixes/adds/changes/removes

1. Removed parameters in the policy_assignment_es_deploy_asc_monitoring.tmpl.json to revert to initiative defaults.
2. Updated display name and description to correctly reflect the initiative assignment objectives.
3. Fixes #528

### Breaking Changes

1. None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["RELEASE"](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues) page with details needed for when this code change is released.
