### PR TITLE
add custom naming of management groups

### DIFF
--- a/locals.management_groups.tf
+++ b/locals.management_groups.tf
@@ -171,43 +171,43 @@ locals {
       archetype_config           = local.es_archetype_config_map[local.root_id]
     }
     "${local.root_id}-decommissioned" = {
-      display_name               = "Decommissioned"
+      display_name               = "Decommissioned${local.mg_suffix}"
       parent_management_group_id = local.root_id
       subscription_ids           = local.es_subscription_ids_map["${local.root_id}-decommissioned"]
       archetype_config           = local.es_archetype_config_map["${local.root_id}-decommissioned"]
     }
     "${local.root_id}-sandboxes" = {
-      display_name               = "Sandboxes"
+      display_name               = "Sandboxes${local.mg_suffix}"
       parent_management_group_id = local.root_id
       subscription_ids           = local.es_subscription_ids_map["${local.root_id}-sandboxes"]
       archetype_config           = local.es_archetype_config_map["${local.root_id}-sandboxes"]
     }
     "${local.root_id}-landing-zones" = {
-      display_name               = "Landing Zones"
+      display_name               = "Landing Zones${local.mg_suffix}"
       parent_management_group_id = local.root_id
       subscription_ids           = local.es_subscription_ids_map["${local.root_id}-landing-zones"]
       archetype_config           = local.es_archetype_config_map["${local.root_id}-landing-zones"]
     }
     "${local.root_id}-platform" = {
-      display_name               = "Platform"
+      display_name               = "Platform${local.mg_suffix}"
       parent_management_group_id = local.root_id
       subscription_ids           = local.es_subscription_ids_map["${local.root_id}-platform"]
       archetype_config           = local.es_archetype_config_map["${local.root_id}-platform"]
     }
     "${local.root_id}-connectivity" = {
-      display_name               = "Connectivity"
+      display_name               = "Connectivity${local.mg_suffix}"
       parent_management_group_id = "${local.root_id}-platform"
       subscription_ids           = local.subscription_ids_connectivity
       archetype_config           = local.es_archetype_config_map["${local.root_id}-connectivity"]
     }
     "${local.root_id}-management" = {
-      display_name               = "Management"
+      display_name               = "Management${local.mg_suffix}"
       parent_management_group_id = "${local.root_id}-platform"
       subscription_ids           = local.subscription_ids_management
       archetype_config           = local.es_archetype_config_map["${local.root_id}-management"]
     }
     "${local.root_id}-identity" = {
-      display_name               = "Identity"
+      display_name               = "Identity${local.mg_suffix}"
       parent_management_group_id = "${local.root_id}-platform"
       subscription_ids           = local.subscription_ids_identity
       archetype_config           = local.es_archetype_config_map["${local.root_id}-identity"]

--- a/locals.tf
+++ b/locals.tf
@@ -12,6 +12,7 @@ locals {
   root_id                          = var.root_id
   root_name                        = var.root_name
   root_parent_id                   = var.root_parent_id
+  mg_suffix                        = var.mg_suffix
   deploy_core_landing_zones        = var.deploy_core_landing_zones
   deploy_corp_landing_zones        = var.deploy_corp_landing_zones
   deploy_online_landing_zones      = var.deploy_online_landing_zones

--- a/variables.tf
+++ b/variables.tf
@@ -36,6 +36,16 @@ variable "root_name" {
   }
 }
 
+variable "mg_suffix" {
+  type        = string
+  description = "If specified, will set a custom Display Name suffix value for the default Management Groups."
+  default     = ""
+  validation {
+    condition     = can(regex("^[A-Za-z0-9- ._]{0,20}[A-Za-z0-9]?$", var.mg_suffix))
+    error_message = "Value must be between 0 to 20 characters long, end with a letter or number, and can only contain space, hyphen, underscore or period characters."
+  }
+}
+
 variable "deploy_core_landing_zones" {
   type        = bool
   description = "If set to true, module will deploy the core Enterprise-scale Management Group hierarchy, including \"out of the box\" policies and roles."


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

See issue https://github.com/Azure/Azure-Landing-Zones/issues/3669

## This PR fixes/adds/changes/removes

1. Adds optional suffix to default management group display_name

### Breaking Changes

None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

I forked the module and provisioned a new canary deployment in my Tenant. Seems to work as expected:

![Screenshot 2022-12-06 at 14 42 18](https://user-images.githubusercontent.com/5646871/205942099-b6d175bd-0c2f-4f8a-a6be-85bbb5e55064.png)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["RELEASE"](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues) page with details needed for when this code change is released.
