### PR TITLE
Revert `Update Library Templates` workflow to use schedule

### DIFF
--- a/.github/workflows/update-policy.yml
+++ b/.github/workflows/update-policy.yml
@@ -1,12 +1,10 @@
 ---
 name: Update Library Templates
 
-# on:
-#   schedule:
-#     - cron: '0 12 1 * *'
-
 # yamllint disable-line rule:truthy
 on:
+  schedule:
+    - cron: "0 8 * * 1-5"
   workflow_dispatch: {}
 
 env:

--- a/.github/workflows/update-policy.yml
+++ b/.github/workflows/update-policy.yml
@@ -4,7 +4,7 @@ name: Update Library Templates
 # yamllint disable-line rule:truthy
 on:
   schedule:
-    - cron: "0 8 * * 1-5"
+    - cron: '0 8 * * 1-5'
   workflow_dispatch: {}
 
 env:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR updates the `Update Library Templates` workflow to run on a daily schedule (weekdays only) at 08:00 to improve visibility of incoming policy changes from the upstream repository.

Will exclude updates to docs as this is an internal process.

## This PR fixes/adds/changes/removes

1. _See description_

### Breaking Changes

none

## Testing Evidence

This change cannot be tested without merging to validate, but updated `cron` is based on previous entry and that used for Bicep implementation.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["RELEASE"](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues) page with details needed for when this code change is released.
