### PR TITLE
Update `optional()` defaults

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -15,6 +15,7 @@ The `v3.1.0` release includes a number of updates as listed below. These focus p
 - Updated managed parameters set for the `Deploy-Private-DNS-Zones` Policy Assignment
 - Updated logic for DNS zone virtual network links to prevent disabled hubs from being included
 - Updated logic for hub virtual network mesh peering to prevent disabled hubs from being included
+- Updated default values for `optional()` connectivity inputs
 - Removed the deprecated `ActivityLog` Azure Monitor solution
 - Removed sensitive value filtering for Log Analytics workspace resources
 - Removed location from `azureBatchPrivateDnsZoneId` parameter for `Deploy-Private-DNS-Zones` policy assignment
@@ -28,6 +29,7 @@ The `v3.1.0` release includes a number of updates as listed below. These focus p
 - Fix [#549](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/549) (Feature Request: Deploy private dns zones and link them to an existing vnet #549)
 - Fix [#553](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/553) (Remove Activity Log solution from Terraform RI #553)
 - Fix [#544](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/544) (Missing assignment parameter values for "Configure Azure PaaS services to use private DNS zones" #544)
+- Fix [#556](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/556) (Unexpected behaviour: Radius IP required when using AAD for VPN gateway #556)
 - Close [#499](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/499) (Bug Report Terraform plan fails due to sensitive values in azurerm_automation_account output #499)
 
 ### Breaking changes

--- a/docs/wiki/[Variables]-configure_connectivity_resources.md
+++ b/docs/wiki/[Variables]-configure_connectivity_resources.md
@@ -238,9 +238,9 @@ object({
                 vpn_client_configuration = optional(list(
                   object({
                     address_space = list(string)
-                    aad_tenant    = optional(string, "")
-                    aad_audience  = optional(string, "")
-                    aad_issuer    = optional(string, "")
+                    aad_tenant    = optional(string, null)
+                    aad_audience  = optional(string, null)
+                    aad_issuer    = optional(string, null)
                     root_certificate = optional(list(
                       object({
                         name             = string
@@ -253,27 +253,27 @@ object({
                         public_cert_data = string
                       })
                     ), [])
-                    radius_server_address = optional(string, "")
-                    radius_server_secret  = optional(string, "")
+                    radius_server_address = optional(string, null)
+                    radius_server_secret  = optional(string, null)
                     vpn_client_protocols  = optional(list(string), [])
                     vpn_auth_types        = optional(list(string), [])
                   })
                 ), [])
                 bgp_settings = optional(list(
                   object({
-                    asn         = number
-                    peer_weight = number
-                    peering_addresses = list(
+                    asn         = optional(number, null)
+                    peer_weight = optional(number, null)
+                    peering_addresses = optional(list(
                       object({
-                        ip_configuration_name = string
-                        apipa_addresses       = list(string)
+                        ip_configuration_name = optional(string, null)
+                        apipa_addresses       = optional(list(string), [])
                       })
-                    )
+                    ), [])
                   })
                 ), [])
                 custom_route = optional(list(
                   object({
-                    address_prefixes = list(string)
+                    address_prefixes = optional(list(string), [])
                   })
                 ), [])
               }), {})
@@ -288,7 +288,7 @@ object({
               sku_tier                      = optional(string, "Standard")
               base_policy_id                = optional(string, "")
               private_ip_ranges             = optional(list(string), [])
-              threat_intelligence_mode      = optional(string, "")
+              threat_intelligence_mode      = optional(string, "Alert")
               threat_intelligence_allowlist = optional(list(string), [])
               availability_zones = optional(object({
                 zone_1 = optional(bool, true)
@@ -329,16 +329,16 @@ object({
                 object({
                   asn         = number
                   peer_weight = number
-                  instance_0_bgp_peering_address = list(
+                  instance_0_bgp_peering_address = optional(list(
                     object({
                       custom_ips = list(string)
                     })
-                  )
-                  instance_1_bgp_peering_address = list(
+                  ), [])
+                  instance_1_bgp_peering_address = optional(list(
                     object({
                       custom_ips = list(string)
                     })
-                  )
+                  ), [])
                 })
               ), [])
               routing_preference = optional(string, "Microsoft Network")
@@ -350,10 +350,10 @@ object({
             config = optional(object({
               enable_dns_proxy              = optional(bool, true)
               dns_servers                   = optional(list(string), [])
-              sku_tier                      = optional(string, "")
+              sku_tier                      = optional(string, "Standard")
               base_policy_id                = optional(string, "")
               private_ip_ranges             = optional(list(string), [])
-              threat_intelligence_mode      = optional(string, "")
+              threat_intelligence_mode      = optional(string, "Alert")
               threat_intelligence_allowlist = optional(list(string), [])
               availability_zones = optional(object({
                 zone_1 = optional(bool, true)

--- a/docs/wiki/[Variables]-configure_connectivity_resources.settings.hub_networks.md
+++ b/docs/wiki/[Variables]-configure_connectivity_resources.settings.hub_networks.md
@@ -102,9 +102,9 @@ object({
           vpn_client_configuration = optional(list(
             object({
               address_space = list(string)
-              aad_tenant    = optional(string, "")
-              aad_audience  = optional(string, "")
-              aad_issuer    = optional(string, "")
+              aad_tenant    = optional(string, null)
+              aad_audience  = optional(string, null)
+              aad_issuer    = optional(string, null)
               root_certificate = optional(list(
                 object({
                   name             = string
@@ -117,27 +117,27 @@ object({
                   public_cert_data = string
                 })
               ), [])
-              radius_server_address = optional(string, "")
-              radius_server_secret  = optional(string, "")
+              radius_server_address = optional(string, null)
+              radius_server_secret  = optional(string, null)
               vpn_client_protocols  = optional(list(string), [])
               vpn_auth_types        = optional(list(string), [])
             })
           ), [])
           bgp_settings = optional(list(
             object({
-              asn         = number
-              peer_weight = number
-              peering_addresses = list(
+              asn         = optional(number, null)
+              peer_weight = optional(number, null)
+              peering_addresses = optional(list(
                 object({
-                  ip_configuration_name = string
-                  apipa_addresses       = list(string)
+                  ip_configuration_name = optional(string, null)
+                  apipa_addresses       = optional(list(string), [])
                 })
-              )
+              ), [])
             })
           ), [])
           custom_route = optional(list(
             object({
-              address_prefixes = list(string)
+              address_prefixes = optional(list(string), [])
             })
           ), [])
         }), {})
@@ -152,7 +152,7 @@ object({
         sku_tier                      = optional(string, "Standard")
         base_policy_id                = optional(string, "")
         private_ip_ranges             = optional(list(string), [])
-        threat_intelligence_mode      = optional(string, "")
+        threat_intelligence_mode      = optional(string, "Alert")
         threat_intelligence_allowlist = optional(list(string), [])
         availability_zones = optional(object({
           zone_1 = optional(bool, true)

--- a/docs/wiki/[Variables]-configure_connectivity_resources.settings.vwan_hub_networks.md
+++ b/docs/wiki/[Variables]-configure_connectivity_resources.settings.vwan_hub_networks.md
@@ -91,16 +91,16 @@ object({
           object({
             asn         = number
             peer_weight = number
-            instance_0_bgp_peering_address = list(
+            instance_0_bgp_peering_address = optional(list(
               object({
                 custom_ips = list(string)
               })
-            )
-            instance_1_bgp_peering_address = list(
+            ), [])
+            instance_1_bgp_peering_address = optional(list(
               object({
                 custom_ips = list(string)
               })
-            )
+            ), [])
           })
         ), [])
         routing_preference = optional(string, "Microsoft Network")
@@ -112,10 +112,10 @@ object({
       config = optional(object({
         enable_dns_proxy              = optional(bool, true)
         dns_servers                   = optional(list(string), [])
-        sku_tier                      = optional(string, "")
+        sku_tier                      = optional(string, "Standard")
         base_policy_id                = optional(string, "")
         private_ip_ranges             = optional(list(string), [])
-        threat_intelligence_mode      = optional(string, "")
+        threat_intelligence_mode      = optional(string, "Alert")
         threat_intelligence_allowlist = optional(list(string), [])
         availability_zones = optional(object({
           zone_1 = optional(bool, true)

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -929,7 +929,7 @@ locals {
         dns_servers                 = try(local.custom_settings.azurerm_firewall["connectivity"][location].dns_servers, null)
         private_ip_ranges           = try(local.custom_settings.azurerm_firewall["connectivity"][location].private_ip_ranges, null)
         management_ip_configuration = try(local.custom_settings.azurerm_firewall["connectivity"][location].management_ip_configuration, local.empty_list)
-        threat_intel_mode           = try(local.custom_settings.azurerm_firewall["connectivity"][location].threat_intel_mode, "Alert")
+        threat_intel_mode           = try(local.custom_settings.azurerm_firewall["connectivity"][location].threat_intel_mode, coalesce(hub_network.config.azure_firewall.config.threat_intelligence_mode, "Alert"))
         virtual_hub                 = local.empty_list
         zones                       = try(local.custom_settings.azurerm_firewall["connectivity"][location].zones, local.azfw_zones[location])
         tags                        = try(local.custom_settings.azurerm_firewall["connectivity"][location].tags, local.tags)

--- a/modules/connectivity/variables.tf
+++ b/modules/connectivity/variables.tf
@@ -74,9 +74,9 @@ variable "settings" {
                 vpn_client_configuration = optional(list(
                   object({
                     address_space = list(string)
-                    aad_tenant    = optional(string, "")
-                    aad_audience  = optional(string, "")
-                    aad_issuer    = optional(string, "")
+                    aad_tenant    = optional(string, null)
+                    aad_audience  = optional(string, null)
+                    aad_issuer    = optional(string, null)
                     root_certificate = optional(list(
                       object({
                         name             = string
@@ -89,27 +89,27 @@ variable "settings" {
                         public_cert_data = string
                       })
                     ), [])
-                    radius_server_address = optional(string, "")
-                    radius_server_secret  = optional(string, "")
+                    radius_server_address = optional(string, null)
+                    radius_server_secret  = optional(string, null)
                     vpn_client_protocols  = optional(list(string), [])
                     vpn_auth_types        = optional(list(string), [])
                   })
                 ), [])
                 bgp_settings = optional(list(
                   object({
-                    asn         = number
-                    peer_weight = number
-                    peering_addresses = list(
+                    asn         = optional(number, null)
+                    peer_weight = optional(number, null)
+                    peering_addresses = optional(list(
                       object({
-                        ip_configuration_name = string
-                        apipa_addresses       = list(string)
+                        ip_configuration_name = optional(string, null)
+                        apipa_addresses       = optional(list(string), [])
                       })
-                    )
+                    ), [])
                   })
                 ), [])
                 custom_route = optional(list(
                   object({
-                    address_prefixes = list(string)
+                    address_prefixes = optional(list(string), [])
                   })
                 ), [])
               }), {})
@@ -124,7 +124,7 @@ variable "settings" {
               sku_tier                      = optional(string, "Standard")
               base_policy_id                = optional(string, "")
               private_ip_ranges             = optional(list(string), [])
-              threat_intelligence_mode      = optional(string, "")
+              threat_intelligence_mode      = optional(string, "Alert")
               threat_intelligence_allowlist = optional(list(string), [])
               availability_zones = optional(object({
                 zone_1 = optional(bool, true)
@@ -165,16 +165,16 @@ variable "settings" {
                 object({
                   asn         = number
                   peer_weight = number
-                  instance_0_bgp_peering_address = list(
+                  instance_0_bgp_peering_address = optional(list(
                     object({
                       custom_ips = list(string)
                     })
-                  )
-                  instance_1_bgp_peering_address = list(
+                  ), [])
+                  instance_1_bgp_peering_address = optional(list(
                     object({
                       custom_ips = list(string)
                     })
-                  )
+                  ), [])
                 })
               ), [])
               routing_preference = optional(string, "Microsoft Network")
@@ -186,10 +186,10 @@ variable "settings" {
             config = optional(object({
               enable_dns_proxy              = optional(bool, true)
               dns_servers                   = optional(list(string), [])
-              sku_tier                      = optional(string, "")
+              sku_tier                      = optional(string, "Standard")
               base_policy_id                = optional(string, "")
               private_ip_ranges             = optional(list(string), [])
-              threat_intelligence_mode      = optional(string, "")
+              threat_intelligence_mode      = optional(string, "Alert")
               threat_intelligence_allowlist = optional(list(string), [])
               availability_zones = optional(object({
                 zone_1 = optional(bool, true)

--- a/variables.tf
+++ b/variables.tf
@@ -248,9 +248,9 @@ variable "configure_connectivity_resources" {
                   vpn_client_configuration = optional(list(
                     object({
                       address_space = list(string)
-                      aad_tenant    = optional(string, "")
-                      aad_audience  = optional(string, "")
-                      aad_issuer    = optional(string, "")
+                      aad_tenant    = optional(string, null)
+                      aad_audience  = optional(string, null)
+                      aad_issuer    = optional(string, null)
                       root_certificate = optional(list(
                         object({
                           name             = string
@@ -263,27 +263,27 @@ variable "configure_connectivity_resources" {
                           public_cert_data = string
                         })
                       ), [])
-                      radius_server_address = optional(string, "")
-                      radius_server_secret  = optional(string, "")
+                      radius_server_address = optional(string, null)
+                      radius_server_secret  = optional(string, null)
                       vpn_client_protocols  = optional(list(string), [])
                       vpn_auth_types        = optional(list(string), [])
                     })
                   ), [])
                   bgp_settings = optional(list(
                     object({
-                      asn         = number
-                      peer_weight = number
-                      peering_addresses = list(
+                      asn         = optional(number, null)
+                      peer_weight = optional(number, null)
+                      peering_addresses = optional(list(
                         object({
-                          ip_configuration_name = string
-                          apipa_addresses       = list(string)
+                          ip_configuration_name = optional(string, null)
+                          apipa_addresses       = optional(list(string), [])
                         })
-                      )
+                      ), [])
                     })
                   ), [])
                   custom_route = optional(list(
                     object({
-                      address_prefixes = list(string)
+                      address_prefixes = optional(list(string), [])
                     })
                   ), [])
                 }), {})
@@ -298,7 +298,7 @@ variable "configure_connectivity_resources" {
                 sku_tier                      = optional(string, "Standard")
                 base_policy_id                = optional(string, "")
                 private_ip_ranges             = optional(list(string), [])
-                threat_intelligence_mode      = optional(string, "")
+                threat_intelligence_mode      = optional(string, "Alert")
                 threat_intelligence_allowlist = optional(list(string), [])
                 availability_zones = optional(object({
                   zone_1 = optional(bool, true)
@@ -339,16 +339,16 @@ variable "configure_connectivity_resources" {
                   object({
                     asn         = number
                     peer_weight = number
-                    instance_0_bgp_peering_address = list(
+                    instance_0_bgp_peering_address = optional(list(
                       object({
                         custom_ips = list(string)
                       })
-                    )
-                    instance_1_bgp_peering_address = list(
+                    ), [])
+                    instance_1_bgp_peering_address = optional(list(
                       object({
                         custom_ips = list(string)
                       })
-                    )
+                    ), [])
                   })
                 ), [])
                 routing_preference = optional(string, "Microsoft Network")
@@ -360,10 +360,10 @@ variable "configure_connectivity_resources" {
               config = optional(object({
                 enable_dns_proxy              = optional(bool, true)
                 dns_servers                   = optional(list(string), [])
-                sku_tier                      = optional(string, "")
+                sku_tier                      = optional(string, "Standard")
                 base_policy_id                = optional(string, "")
                 private_ip_ranges             = optional(list(string), [])
-                threat_intelligence_mode      = optional(string, "")
+                threat_intelligence_mode      = optional(string, "Alert")
                 threat_intelligence_allowlist = optional(list(string), [])
                 availability_zones = optional(object({
                   zone_1 = optional(bool, true)


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR updates a number of default values for `optional()` connectivity inputs within the `configure_connectivity_resources` to allow `null` values to correctly pass-through as needed for optional resource attributes.

## This PR fixes/adds/changes/removes

1. Fixes #556 

### Breaking Changes

None

## Testing Evidence

Please see outcome of `/azp run update` as this should show no changes from this PR.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["RELEASE"](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues) page with details needed for when this code change is released.
