### PR TITLE
Support existing RSG for VWAN

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -83,6 +83,7 @@ module "connectivity_resources" {
   resource_suffix                           = lookup(local.connectivity_resources_advanced, "resource_suffix", local.empty_string)
   existing_ddos_protection_plan_resource_id = lookup(local.connectivity_resources_advanced, "existing_ddos_protection_plan_resource_id", local.empty_string)
   existing_virtual_wan_resource_id          = lookup(local.connectivity_resources_advanced, "existing_virtual_wan_resource_id", local.empty_string)
+  existing_virtual_wan_resource_group_name  = lookup(local.connectivity_resources_advanced, "existing_virtual_wan_resource_group_name", local.empty_string)
   resource_group_per_virtual_hub_location   = lookup(local.connectivity_resources_advanced, "resource_group_per_virtual_hub_location", false)
   custom_azure_backup_geo_codes             = lookup(local.connectivity_resources_advanced, "custom_azure_backup_geo_codes", local.empty_map)
   custom_settings_by_resource_type          = lookup(local.connectivity_resources_advanced, "custom_settings_by_resource_type", local.empty_map)

--- a/modules/connectivity/variables.tf
+++ b/modules/connectivity/variables.tf
@@ -326,6 +326,12 @@ variable "existing_virtual_wan_resource_id" {
   default     = ""
 }
 
+variable "existing_virtual_wan_resource_group_name" {
+  type        = string
+  description = "If specified, module will skip creation of the Virtual WAN resource group and use existing. All Virtual Hubs created by the module will be created in the specified Virtual WAN resource group."
+  default     = ""
+}
+
 variable "resource_group_per_virtual_hub_location" {
   type        = bool
   description = "If set to true, module will place each Virtual Hub (and associated resources) in a location-specific Resource Group. Default behaviour is to colocate Virtual Hub resources in the same Resource Group as the Virtual WAN resource."


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR adds support for specifying an existing resource group name for virtual WAN resources.

When specified, all virtual WAN resources will be created in the target resource group.

## This PR fixes/adds/changes/removes

1. Fixes #552

### Breaking Changes

None

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [ ] Updated the ["RELEASE"](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues) page with details needed for when this code change is released.
