### PR TITLE
Disable DDoS protection by default

### DIFF
--- a/docs/wiki/[Examples]-Deploy-using-multiple-module-declarations-with-orchestration.md
+++ b/docs/wiki/[Examples]-Deploy-using-multiple-module-declarations-with-orchestration.md
@@ -220,7 +220,7 @@ variable "log_retention_in_days" {
 variable "enable_ddos_protection" {
   type        = bool
   description = "Controls whether to create a DDoS Network Protection plan and link to hub virtual networks."
-  default     = true
+  default     = false
 }
 
 variable "connectivity_resources_tags" {

--- a/docs/wiki/[Examples]-Deploy-using-multiple-module-declarations-with-remote-state.md
+++ b/docs/wiki/[Examples]-Deploy-using-multiple-module-declarations-with-remote-state.md
@@ -252,7 +252,7 @@ variable "subscription_id_connectivity" {
 variable "enable_ddos_protection" {
   type        = bool
   description = "Controls whether to create a DDoS Network Protection plan and link to hub virtual networks."
-  default     = true
+  default     = false
 }
 
 variable "connectivity_resources_tags" {

--- a/examples/400-multi-with-orchestration/variables.tf
+++ b/examples/400-multi-with-orchestration/variables.tf
@@ -57,7 +57,7 @@ variable "log_retention_in_days" {
 variable "enable_ddos_protection" {
   type        = bool
   description = "Controls whether to create a DDoS Network Protection plan and link to hub virtual networks."
-  default     = true
+  default     = false
 }
 
 variable "connectivity_resources_tags" {

--- a/examples/400-multi-with-remote-state/connectivity/variables.tf
+++ b/examples/400-multi-with-remote-state/connectivity/variables.tf
@@ -26,7 +26,7 @@ variable "subscription_id_connectivity" {
 variable "enable_ddos_protection" {
   type        = bool
   description = "Controls whether to create a DDoS Network Protection plan and link to hub virtual networks."
-  default     = true
+  default     = false
 }
 
 variable "connectivity_resources_tags" {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR updates the recently added examples for deploying using multiple module declarations, to disable deployment of DDoS protection by default.

This change is to reduce the risk of bill-shock due to the high cost of this service.

## This PR fixes/adds/changes/removes

n/a

### Breaking Changes

n/a

## Testing Evidence

n/a

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["RELEASE"](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues) page with details needed for when this code change is released.
