### PR TITLE
remove duplicate category RouteDiagnosticLog from log settings

### DIFF
--- a/modules/archetypes/lib/policy_definitions/policy_definition_es_deploy_diagnostics_vnetgw.json
+++ b/modules/archetypes/lib/policy_definitions/policy_definition_es_deploy_diagnostics_vnetgw.json
@@ -167,10 +167,6 @@
                           "enabled": "[parameters('logsEnabled')]"
                         },
                         {
-                          "category": "RouteDiagnosticLog",
-                          "enabled": "[parameters('logsEnabled')]"
-                        },
-                        {
                           "category": "TunnelDiagnosticLog",
                           "enabled": "[parameters('logsEnabled')]"
                         }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Fixes duplicate Log-Property in Policy Definition _Deploy-Diagnostics-VNetGW_ that prevents policy remediation, as described in #611.

## This PR fixes/adds/changes/removes

1. Removes log category _RouteDiagnosticLog_ from policy deployment template

### Breaking Changes

- none - 

## Testing Evidence

Tested remediation on policy before and after change with different outcomes. 
![image](https://user-images.githubusercontent.com/10231267/218047676-5c270986-853c-4782-9052-716ca466ca67.png)

1. Outcome without fix: 
![image](https://user-images.githubusercontent.com/10231267/218048036-04b8af68-98ff-43ae-bbbe-4928b7776c0e.png)

2. Outcome with fix:
![image](https://user-images.githubusercontent.com/10231267/218048544-e11980f2-9a6f-4e73-bcb2-9f3db3fda11e.png)


## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [X] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["RELEASE"](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues) page with details needed for when this code change is released.
