### PR TITLE
Update parameter merge logic

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -6,6 +6,7 @@ The `v3.2.0` release includes ...
 
 ### New features
 
+- Added new logic to merge parameters for policy assignments on a per-parameter basis, rather than per-assignment to simplify editing individual parameter values at different scopes.
 - Updated the `description` field for the `vulnerabilityAssessmentsEmail` parameter on the `Deploy-Sql-vulnerabilityAssessments` policy definition to provide clearer guidance on how to specify multiple email addresses.
 - Updated description for `archetype_config_overrides` input variable.
 - Updated the `displayName` field for the `Deny-MachineLearning-PublicAccessWhenBehindVnet` policy definition (to correct spelling mistake).
@@ -14,6 +15,7 @@ The `v3.2.0` release includes ...
 
 - Fix [130](https://github.com/Azure/Enterprise-Scale/issues/130) (Deploy-Sql-vulnerabilityAssessments definition vulnerabilityAssessmentsEmail parameter type should be a list #130)
 - Fix [573](https://github.com/Azure/Enterprise-Scale/issues/573) ("archetype_config_overrides" has no effect on management groups (module version 2.4.0) #573)
+- Fix [607](https://github.com/Azure/Enterprise-Scale/issues/607) (Policy Assignment Deploy-Resource-Diag -> logAnalytics Subscription ID is 00000000-0000-0000-0000-00 0000000000 #607)
 
 ### Breaking changes
 

--- a/docs/wiki/[User-Guide]-Archetype-Definitions.md
+++ b/docs/wiki/[User-Guide]-Archetype-Definitions.md
@@ -178,8 +178,15 @@ This must reference a valid `archetype_definition` from the built-in or custom l
 - `parameters` provides the option to set parameter values for any Policy Assignment(s) specified within the chosen archetype definition.
 To target a specific Policy Assignment, create a new `map()` entry using the Policy Assignment `name` field as the `key`.
 The `value` should be an `object({})` containing `key/value` pairs for each `parameter` needed by the Policy Assignment.
+To simplify working with parameters at different scopes within the module, parameters for a given policy assignment are merged in the following order:
 
-  > **NOTE:** that parameters are specified as simple `key/value` pairs, and do not require the same structure used in native ARM templates.
+  1. Default values from within the base definition or initiative
+  1. Values defined within a policy assignment template
+  1. Values provided within the `archetype_config.parameters` object from an archetype definition template
+  1. Values managed by the module (*such as the `logAnayltics` value commonly set in many of our bundled policy assignments*)
+  1. Values provided within the `archetype_config.parameters` object from either the `archetype_config_overrides` or `custom_landing_zones` input
+
+  > **NOTE:** Parameters are specified as simple `key/value` pairs in the module, and do not require the same structure used in native ARM templates.
 
 - `access_control` provides the option to add user-specified Role Assignments which will be added to the specified Management Group.
 To avoid a direct dependency on the [Azure Active Directory Provider][azuread_provider], this module requires the input to be a list of Object IDs for each Azure AD object you want to assign the specified permission.

--- a/locals.tf
+++ b/locals.tf
@@ -78,6 +78,9 @@ locals {
     local.create_object,
     coalesce(local.configure_management_resources.advanced, local.empty_map)
   )
+  parameter_map_default = {
+    parameters = local.empty_map
+  }
 }
 
 # The following locals are used to define a set of module

--- a/modules/archetypes/locals.tf
+++ b/modules/archetypes/locals.tf
@@ -71,6 +71,15 @@ locals {
   )
 }
 
+# The following locals are used to specify default values for the lookup() function
+locals {
+  parameter_map_default = {
+    properties = {
+      parameters = local.empty_map
+    }
+  }
+}
+
 # Generate the configuration output object for the specified archetype
 # depends_on_files = [
 #   locals.policy_assignments.tf

--- a/tests/modules/settings/settings.core.tf
+++ b/tests/modules/settings/settings.core.tf
@@ -127,14 +127,27 @@ locals {
             "ukwest",
           ]
         }
+        # The following policy has only a subset of mandatory parameters set using this input.
+        # This is to prove that the defaults set in the policy assignment template are correctly merged.
         Deploy-HITRUST-HIPAA = {
-          CertificateThumbprints                                        = ""
           DeployDiagnosticSettingsforNetworkSecurityGroupsrgName        = "${var.root_id}-rg"
           DeployDiagnosticSettingsforNetworkSecurityGroupsstoragePrefix = var.root_id
-          installedApplicationsOnWindowsVM                              = ""
           listOfLocations = [
             "eastus",
+            "eastus2",
+            "westus",
+            "northcentralus",
+            "southcentralus",
+            "northeurope",
+            "westeurope",
+            "uksouth",
+            "ukwest",
           ]
+        }
+        # The following policy has only a subset of mandatory parameters set using this input.
+        # This is to prove that the managed values set by the module are correctly merged.
+        Deploy-Resource-Diag = {
+          AKSLogAnalyticsEffect = "Disabled"
         }
       }
       access_control = {}

--- a/tests/modules/test_002_add_custom_core/baseline_values.json
+++ b/tests/modules/test_002_add_custom_core/baseline_values.json
@@ -2400,7 +2400,7 @@
               "name": "Deploy-HITRUST-HIPAA",
               "non_compliance_message": [],
               "not_scopes": [],
-              "parameters": "{\"CertificateThumbprints\":{\"value\":\"\"},\"DeployDiagnosticSettingsforNetworkSecurityGroupsrgName\":{\"value\":\"root-id-1-rg\"},\"DeployDiagnosticSettingsforNetworkSecurityGroupsstoragePrefix\":{\"value\":\"root-id-1\"},\"installedApplicationsOnWindowsVM\":{\"value\":\"\"},\"listOfLocations\":{\"value\":[\"eastus\"]}}",
+              "parameters": "{\"CertificateThumbprints\":{\"value\":\"\"},\"DeployDiagnosticSettingsforNetworkSecurityGroupsrgName\":{\"value\":\"root-id-1-rg\"},\"DeployDiagnosticSettingsforNetworkSecurityGroupsstoragePrefix\":{\"value\":\"root-id-1\"},\"installedApplicationsOnWindowsVM\":{\"value\":\"\"},\"listOfLocations\":{\"value\":[\"eastus\",\"eastus2\",\"westus\",\"northcentralus\",\"southcentralus\",\"northeurope\",\"westeurope\",\"uksouth\",\"ukwest\"]}}",
               "policy_definition_id": "/providers/Microsoft.Authorization/policySetDefinitions/a169a624-5599-4385-a696-c8d643089fab",
               "timeouts": null
             },
@@ -2470,7 +2470,7 @@
               "name": "Deploy-Resource-Diag",
               "non_compliance_message": [],
               "not_scopes": [],
-              "parameters": "{\"logAnalytics\":{\"value\":\"/subscriptions/a9d8bda7-a341-4fe2-bfbf-61145868379e/resourceGroups/root-id-1-mgmt/providers/Microsoft.OperationalInsights/workspaces/root-id-1-la\"}}",
+              "parameters": "{\"AKSLogAnalyticsEffect\":{\"value\":\"Disabled\"},\"logAnalytics\":{\"value\":\"/subscriptions/a9d8bda7-a341-4fe2-bfbf-61145868379e/resourceGroups/root-id-1-mgmt/providers/Microsoft.OperationalInsights/workspaces/root-id-1-la\"}}",
               "policy_definition_id": "/providers/Microsoft.Management/managementGroups/root-id-1/providers/Microsoft.Authorization/policySetDefinitions/Deploy-Diagnostics-LogAnalytics",
               "timeouts": null
             },

--- a/tests/modules/test_003_add_mgmt_conn/baseline_values.json
+++ b/tests/modules/test_003_add_mgmt_conn/baseline_values.json
@@ -7359,7 +7359,7 @@
               "name": "Deploy-HITRUST-HIPAA",
               "non_compliance_message": [],
               "not_scopes": [],
-              "parameters": "{\"CertificateThumbprints\":{\"value\":\"\"},\"DeployDiagnosticSettingsforNetworkSecurityGroupsrgName\":{\"value\":\"root-id-1-rg\"},\"DeployDiagnosticSettingsforNetworkSecurityGroupsstoragePrefix\":{\"value\":\"root-id-1\"},\"installedApplicationsOnWindowsVM\":{\"value\":\"\"},\"listOfLocations\":{\"value\":[\"eastus\"]}}",
+              "parameters": "{\"CertificateThumbprints\":{\"value\":\"\"},\"DeployDiagnosticSettingsforNetworkSecurityGroupsrgName\":{\"value\":\"root-id-1-rg\"},\"DeployDiagnosticSettingsforNetworkSecurityGroupsstoragePrefix\":{\"value\":\"root-id-1\"},\"installedApplicationsOnWindowsVM\":{\"value\":\"\"},\"listOfLocations\":{\"value\":[\"eastus\",\"eastus2\",\"westus\",\"northcentralus\",\"southcentralus\",\"northeurope\",\"westeurope\",\"uksouth\",\"ukwest\"]}}",
               "policy_definition_id": "/providers/Microsoft.Authorization/policySetDefinitions/a169a624-5599-4385-a696-c8d643089fab",
               "timeouts": null
             },
@@ -7429,7 +7429,7 @@
               "name": "Deploy-Resource-Diag",
               "non_compliance_message": [],
               "not_scopes": [],
-              "parameters": "{\"logAnalytics\":{\"value\":\"/subscriptions/a9d8bda7-a341-4fe2-bfbf-61145868379e/resourceGroups/root-id-1-mgmt/providers/Microsoft.OperationalInsights/workspaces/root-id-1-la\"}}",
+              "parameters": "{\"AKSLogAnalyticsEffect\":{\"value\":\"Disabled\"},\"logAnalytics\":{\"value\":\"/subscriptions/a9d8bda7-a341-4fe2-bfbf-61145868379e/resourceGroups/root-id-1-mgmt/providers/Microsoft.OperationalInsights/workspaces/root-id-1-la\"}}",
               "policy_definition_id": "/providers/Microsoft.Management/managementGroups/root-id-1/providers/Microsoft.Authorization/policySetDefinitions/Deploy-Diagnostics-LogAnalytics",
               "timeouts": null
             },

--- a/tests/modules/test_lib/policy_assignments/policy_assignment_test_policy_set_definition.json
+++ b/tests/modules/test_lib/policy_assignments/policy_assignment_test_policy_set_definition.json
@@ -8,16 +8,16 @@
         "notScopes": [],
         "parameters": {
             "installedApplicationsOnWindowsVM": {
-                "value": null
+                "value": ""
             },
             "DeployDiagnosticSettingsforNetworkSecurityGroupsstoragePrefix": {
-                "value": null
+                "value": ""
             },
             "DeployDiagnosticSettingsforNetworkSecurityGroupsrgName": {
-                "value": null
+                "value": ""
             },
             "CertificateThumbprints": {
-                "value": null
+                "value": ""
             }
         },
         "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/a169a624-5599-4385-a696-c8d643089fab",


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR includes an update to the way parameters for policy assignments are merged when specified in different locations.

Currently, parameters are merged on a "per-policy" basis. This means that anyone wanting to specify custom values must ensure ALL required parameters are set for the target policy assignment. This can be challenging to get right, especially when amending policies with parameter managed dynamically by the module as discussed in #607.

This PR adds new logic which allows us to merge custom values on a "per-parameter" basis. This ensures that parameter values set at lower scopes are retained unless explicitly overwritten.

## This PR fixes/adds/changes/removes

1. Fix #607

### Breaking Changes

None. Customer who are already specifying custom parameter values will have had to specify all parameters at the target scope. This change will not impact those customers, and doesn't change the default behaviour of the default assignments.

## Testing Evidence

Updates made to test framework to show behaviour.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
- [x] Updated the ["RELEASE"](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues) page with details needed for when this code change is released.
