### PR TITLE
Support for default tags in azurerm_firewall_policy resource

### DIFF
--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -968,7 +968,7 @@ locals {
           intrusion_detection  = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].intrusion_detection, local.empty_list)
           tls_certificate      = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].tls_certificate, local.empty_list)
           sql_redirect_allowed = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].sql_redirect_allowed, null)
-          tags                 = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].tags, null)
+          tags                 = try(local.custom_settings.azurerm_firewall_policy["connectivity"][location].tags, local.tags)
         }
         # Child resource definition attributes
         azurerm_public_ip = (
@@ -1055,7 +1055,7 @@ locals {
           identity            = try(local.custom_settings.azurerm_firewall_policy["virtual_wan"][location].identity, local.empty_list)
           insights            = try(local.custom_settings.azurerm_firewall_policy["virtual_wan"][location].insights, local.empty_list)
           intrusion_detection = try(local.custom_settings.azurerm_firewall_policy["virtual_wan"][location].intrusion_detection, local.empty_list)
-          tags                = try(local.custom_settings.azurerm_firewall_policy["virtual_wan"][location].tags, null)
+          tags                = try(local.custom_settings.azurerm_firewall_policy["virtual_wan"][location].tags, local.tags)
         }
         # Child resource definition attributes
         azurerm_public_ip = local.empty_list


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary
Changed from `null` to `local.tags` for the Firewall Policy (both the traditional hub-spoke edition and the Virtual WAN edition). With this change the `default_tags` are also applied to the Firewall Policy.

## This PR fixes/adds/changes/removes

1. Adds support for default tags for the Firewall Policy resource.

Issue: #627

### Breaking Changes
None.

## Testing Evidence
Before the change:
![image](https://user-images.githubusercontent.com/62336565/221529097-246959b0-d00e-4435-b7df-c37a096503d1.png)

After the change:
![image](https://user-images.githubusercontent.com/62336565/221529632-b0476766-b18c-4d68-8d09-3f49107b0967.png)

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [X] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
- [ ] Updated the ["RELEASE"](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues) page with details needed for when this code change is released.
