### PR TITLE
Module Telemetry Enhancements/Additions - Custom Library & Zero Trust Networking Phase 1

### DIFF
--- a/locals.telemetry.connectivity.tf
+++ b/locals.telemetry.connectivity.tf
@@ -29,7 +29,8 @@ locals {
 
   # Bitfield bit 5: Zero Trust Network - Phase 1 configured?
   telem_connectivity_ztn_p1 = (local.configure_connectivity_resources.settings.ddos_protection_plan.enabled &&
-    (alltrue([for sku in local.configure_connectivity_resources.settings.hub_networks.*.config.azure_firewall.config.sku_tier : sku == "Premium"]) || alltrue([for sku in local.configure_connectivity_resources.settings.vwan_hub_networks.*.config.azure_firewall.config.sku_tier : sku == "Premium"])) &&
+    alltrue(flatten([[for azfw in local.configure_connectivity_resources.settings.hub_networks.*.config.azure_firewall.enabled : azfw == true], [for azfw in local.configure_connectivity_resources.settings.vwan_hub_networks.*.config.azure_firewall.enabled : azfw == true]])) &&
+    alltrue(flatten([[for sku in local.configure_connectivity_resources.settings.hub_networks.*.config.azure_firewall.config.sku_tier : sku == "Premium"], [for sku in local.configure_connectivity_resources.settings.vwan_hub_networks.*.config.azure_firewall.config.sku_tier : sku == "Premium"]])) &&
     local.telem_subnet_nsg_policy_assignment_exists &&
     local.telem_storage_https_policy_assignment_exists
   ? 16 : 0)

--- a/locals.telemetry.connectivity.tf
+++ b/locals.telemetry.connectivity.tf
@@ -16,6 +16,11 @@ locals {
 
   # Bitfield bit 4: DNS configured?
   telem_connectivity_configure_dns = local.configure_connectivity_resources.settings.dns.enabled ? 8 : 0
+
+  # Bitfield bit 5: Zero Trust Network - Phase 1 configured?
+  telem_connectivity_ztn_p1 = (local.configure_connectivity_resources.settings.ddos_protection_plan.enabled &&
+    (alltrue([for sku in local.configure_connectivity_resources.settings.hub_networks.*.config.azure_firewall.config.sku_tier : sku == "Premium"]) || alltrue([for sku in local.configure_connectivity_resources.settings.vwan_hub_networks.*.config.azure_firewall.config.sku_tier : sku == "Premium"]))
+    ? 16 : 0)
 }
 
 # The following locals calculate the telemetry bit field by summiung the above locals and then representing as hexadecimal
@@ -25,7 +30,8 @@ locals {
     local.telem_connectivity_configure_hub_networks +
     local.telem_connectivity_configure_vwan_hub_networks +
     local.telem_connectivity_configure_ddos_protection_plan +
-    local.telem_connectivity_configure_dns
+    local.telem_connectivity_configure_dns +
+    local.telem_connectivity_ztn_p1
   )
   telem_connectivity_bitfield_hex = format("%04x", local.telem_connectivity_bitfield_denery)
 }

--- a/locals.telemetry.connectivity.tf
+++ b/locals.telemetry.connectivity.tf
@@ -3,7 +3,7 @@
 
 # This file contains telemetry for the connectivity module
 
-# The following locals are used to check for the existence of policy assignments that are made by the module that support a Zero Trust Networking configuration that is requried for telemetry triggers below
+# The following locals are used to check for the existence of policy assignments that are made by the module that support a Zero Trust Networking configuration that is requried for telemetry triggers below - https://github.com/Azure/Enterprise-Scale/wiki/Deploying-ALZ-CustomerUsage#alz-acceleratoreslz-arm-deployment---zero-trust-networking---phase-1--definition
 locals {
   telem_subnet_nsg_policy_assignment_exists = length([for k, v in local.azurerm_management_group_policy_assignment_enterprise_scale :
     k if contains(split("/", v.template.properties.policyDefinitionId), "Deny-Subnet-Without-Nsg") && contains(split("/", k), "Deny-Subnet-Without-Nsg") && (endswith(split("/", k)[4], "-identity") || endswith(split("/", k)[4], "-landing-zones"))
@@ -27,7 +27,7 @@ locals {
   # Bitfield bit 4: DNS configured?
   telem_connectivity_configure_dns = local.configure_connectivity_resources.settings.dns.enabled ? 8 : 0
 
-  # Bitfield bit 5: Zero Trust Network - Phase 1 configured?
+  # Bitfield bit 5: Zero Trust Network - Phase 1 configured? - https://github.com/Azure/Enterprise-Scale/wiki/Deploying-ALZ-CustomerUsage#alz-acceleratoreslz-arm-deployment---zero-trust-networking---phase-1--definition
   telem_connectivity_ztn_p1 = (local.configure_connectivity_resources.settings.ddos_protection_plan.enabled &&
     alltrue(flatten([[for azfw in local.configure_connectivity_resources.settings.hub_networks.*.config.azure_firewall.enabled : azfw == true], [for azfw in local.configure_connectivity_resources.settings.vwan_hub_networks.*.config.azure_firewall.enabled : azfw == true]])) &&
     alltrue(flatten([[for sku in local.configure_connectivity_resources.settings.hub_networks.*.config.azure_firewall.config.sku_tier : sku == "Premium"], [for sku in local.configure_connectivity_resources.settings.vwan_hub_networks.*.config.azure_firewall.config.sku_tier : sku == "Premium"]])) &&

--- a/locals.telemetry.core.tf
+++ b/locals.telemetry.core.tf
@@ -19,6 +19,9 @@ locals {
 
   # Bitfield bit 5: Are there any custom LZs configured?
   telem_core_custom_lzs_configured = length(local.custom_landing_zones) > 0 ? 16 : 0
+
+  # Bitfield bit 6: Is a custom library path set?
+  telem_core_custom_lib_configured = local.library_path != "" ? 32 : 0
 }
 
 # The following locals calculate the telemetry bit field by summiung the above locals and then representing as hexadecimal
@@ -29,7 +32,8 @@ locals {
     local.telem_core_deploy_corp_landing_zones +
     local.telem_core_deploy_online_landing_zones +
     local.telem_core_deploy_sap_landing_zones +
-    local.telem_core_custom_lzs_configured
+    local.telem_core_custom_lzs_configured +
+    local.telem_core_custom_lib_configured
   )
   telem_core_bitfield_hex = format("%04x", local.telem_core_bitfield_denery)
 }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR adds adds some new telemetry collection to the existing bitfield deployments so we can learn more about how the module is being used.

## This PR fixes/adds/changes/removes

1. [AB#27173](https://dev.azure.com/CSUSolEng/2a9d5a5a-8998-4ad0-81c8-ef3045e4da97/_workitems/edit/27173) - Zero Trust Networking Phase 1 - https://github.com/Azure/Enterprise-Scale/wiki/Deploying-ALZ-CustomerUsage#alz-acceleratoreslz-arm-deployment---zero-trust-networking---phase-1--definition
2. Telemetry for Custom Library Enabled

### Breaking Changes

None

## Testing Evidence
![image](https://user-images.githubusercontent.com/41163455/229577704-b8fe6290-6e73-4296-81df-1f592d0fe4a0.png)
Screenshot of deploying module with defaults and then adding connectivity config with AzFW Premium 

Can be seen on internal dashboards from test deployment

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
