### PR TITLE
lookup enforcement mode from overwrite config

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,7 @@ module "management_group_archetypes" {
   template_file_variables = local.template_file_variables
   default_location        = local.default_location
   enforcement_mode = merge(
+    lookup(var.archetype_config_overrides, basename(each.key), local.enforcement_mode_default).enforcement_mode,
     lookup(module.connectivity_resources.configuration.archetype_config_overrides, basename(each.key), local.enforcement_mode_default).enforcement_mode,
     lookup(module.identity_resources.configuration.archetype_config_overrides, basename(each.key), local.enforcement_mode_default).enforcement_mode,
     lookup(module.management_resources.configuration.archetype_config_overrides, basename(each.key), local.enforcement_mode_default).enforcement_mode,

--- a/main.tf
+++ b/main.tf
@@ -17,10 +17,10 @@ module "management_group_archetypes" {
   template_file_variables = local.template_file_variables
   default_location        = local.default_location
   enforcement_mode = merge(
-    lookup(var.archetype_config_overrides, basename(each.key), local.enforcement_mode_default).enforcement_mode,
     lookup(module.connectivity_resources.configuration.archetype_config_overrides, basename(each.key), local.enforcement_mode_default).enforcement_mode,
     lookup(module.identity_resources.configuration.archetype_config_overrides, basename(each.key), local.enforcement_mode_default).enforcement_mode,
     lookup(module.management_resources.configuration.archetype_config_overrides, basename(each.key), local.enforcement_mode_default).enforcement_mode,
+    lookup(var.archetype_config_overrides, basename(each.key), local.enforcement_mode_default).enforcement_mode,
   )
 }
 


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Every policy can be set with enforcement_mode true or false, which is on the same level as parameters. Beforehand, it was only possible to overwrite the enforcement mode for policies set on the connectivity, identity and management group. For policies which are applied e.g. on the landing zones, it was possible to set the parameters, but not the enforcement mode.

## This PR fixes/adds/changes/removes

1. In the overwrite config, it is possible to set the enforcement mode for all policies. Potential overwrite configuration can be like this:
```

locals {
  archetype_config_overrides = {    
    es-landing-zones = {
      enforcement_mode = {
        Deny-Public-IP          = false
        Deny-RDP-From-Internet  = false
        Deny-Subnet-Without-Nsg = false
        Deploy-VM-Backup        = false
      }
    }
  }
}
```


### Breaking Changes

none, the configuration is optional

## Testing Evidence

The above configuration works. I am happy to also write a page for the wiki with a longer how-to.

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [X] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation. --> I can write a wiki page with a sample
