### PR TITLE
ci: increase job timeout to prevent tf state locking

### DIFF
--- a/tests/pipelines/tests-e2e.yml
+++ b/tests/pipelines/tests-e2e.yml
@@ -31,7 +31,8 @@ jobs:
       STORAGE_ACCOUNT_RSG_NAME: $[ dependencies.backend_generator.outputs['prepare_backend.STORAGE_ACCOUNT_RSG_NAME'] ]
       STORAGE_ACCOUNT_NAME: $[ dependencies.backend_generator.outputs['prepare_backend.STORAGE_ACCOUNT_NAME'] ]
       STORAGE_CONTAINER_NAME: $[ dependencies.backend_generator.outputs['prepare_backend.STORAGE_CONTAINER_NAME'] ]
-    timeoutInMinutes: 30
+    timeoutInMinutes: 120
+    cancelTimeoutInMinutes: 120
     steps:
       - template: templates/tests-common.yml
 
@@ -52,7 +53,8 @@ jobs:
       STORAGE_ACCOUNT_RSG_NAME: $[ dependencies.backend_generator.outputs['prepare_backend.STORAGE_ACCOUNT_RSG_NAME'] ]
       STORAGE_ACCOUNT_NAME: $[ dependencies.backend_generator.outputs['prepare_backend.STORAGE_ACCOUNT_NAME'] ]
       STORAGE_CONTAINER_NAME: $[ dependencies.backend_generator.outputs['prepare_backend.STORAGE_CONTAINER_NAME'] ]
-    timeoutInMinutes: 30
+    timeoutInMinutes: 120
+    cancelTimeoutInMinutes: 120
     steps:
       - template: templates/tests-common.yml
 
@@ -73,7 +75,8 @@ jobs:
       STORAGE_ACCOUNT_RSG_NAME: $[ dependencies.backend_generator.outputs['prepare_backend.STORAGE_ACCOUNT_RSG_NAME'] ]
       STORAGE_ACCOUNT_NAME: $[ dependencies.backend_generator.outputs['prepare_backend.STORAGE_ACCOUNT_NAME'] ]
       STORAGE_CONTAINER_NAME: $[ dependencies.backend_generator.outputs['prepare_backend.STORAGE_CONTAINER_NAME'] ]
-    timeoutInMinutes: 60
+    timeoutInMinutes: 120
+    cancelTimeoutInMinutes: 120
     steps:
       - template: templates/tests-common.yml
 
@@ -94,8 +97,8 @@ jobs:
       STORAGE_ACCOUNT_RSG_NAME: $[ dependencies.backend_generator.outputs['prepare_backend.STORAGE_ACCOUNT_RSG_NAME'] ]
       STORAGE_ACCOUNT_NAME: $[ dependencies.backend_generator.outputs['prepare_backend.STORAGE_ACCOUNT_NAME'] ]
       STORAGE_CONTAINER_NAME: $[ dependencies.backend_generator.outputs['prepare_backend.STORAGE_CONTAINER_NAME'] ]
-    timeoutInMinutes: 60
-    cancelTimeoutInMinutes: 60
+    timeoutInMinutes: 120
+    cancelTimeoutInMinutes: 120
     condition: |
       or
       (


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Timeouts of 1 hour insufficient to prevent job cancellation and state file locking

Increases to 2h 