### PR TITLE
feat: add policy exemption to overwrites

### DIFF
--- a/locals.policy_exemption.tf
+++ b/locals.policy_exemption.tf
@@ -1,0 +1,44 @@
+locals {
+  policy_mitigated = flatten([
+    for k, v in local.azurerm_management_group_policy_assignment_enterprise_scale : [
+      # reverse(split("/", v.scope_id))[0] # archetype_id
+      for overwrite in
+      # lookup archetype_id --> policy_exemption --> policy_name --> this gives a list of all the exemption from this policy
+      lookup(lookup(lookup(var.archetype_config_overrides, reverse(split("/", v.scope_id))[0], {}), "policy_exemption", {}), v.template.name, [])
+      : [
+        {
+          scope : v.template.properties.scope
+          policy_assignment_id : k
+          overwrite_id : overwrite
+          name : v.template.name
+          metadata = try(length(v.template.properties.metadata) > 0, false) ? jsonencode(v.template.properties.metadata) : null
+          is_subscription : length(regexall("/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/?$", overwrite)) > 0
+          is_resource_group : length(regexall("/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/resourceGroups/[^/]*/?$", overwrite)) > 0
+        }
+      ]
+    ]
+    ]
+  )
+  initiative_mitigated = flatten([
+    for k, v in local.azurerm_management_group_policy_assignment_enterprise_scale : [
+      # reverse(split("/", v.scope_id))[0] # archetype_id
+      for overwrite_key, overwrite_value in
+      # lookup archetype_id --> policy_exemption --> policy_name --> this gives a list of all the exemption from this policy
+      lookup(lookup(lookup(var.archetype_config_overrides, reverse(split("/", v.scope_id))[0], {}), "initiative_exemption", {}), v.template.name, []) : [
+        for overwrite in overwrite_value : [
+          {
+            scope : v.template.properties.scope
+            policy_assignment_id : k
+            overwrite_id : overwrite
+            name : v.template.name
+            metadata = try(length(v.template.properties.metadata) > 0, false) ? jsonencode(v.template.properties.metadata) : null
+            is_subscription : length(regexall("/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/?$", overwrite)) > 0
+            is_resource_group : length(regexall("/subscriptions/[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}/resourceGroups/[^/]*/?$", overwrite)) > 0
+            policy_definition_reference_ids : [overwrite_key]
+          }
+        ]
+      ]
+    ]
+    ]
+  )
+}

--- a/locals.policy_exemption.tf
+++ b/locals.policy_exemption.tf
@@ -1,9 +1,7 @@
 locals {
   policy_mitigated = flatten([
     for k, v in local.azurerm_management_group_policy_assignment_enterprise_scale : [
-      # reverse(split("/", v.scope_id))[0] # archetype_id
       for overwrite in
-      # lookup archetype_id --> policy_exemption --> policy_name --> this gives a list of all the exemption from this policy
       lookup(lookup(lookup(var.archetype_config_overrides, reverse(split("/", v.scope_id))[0], {}), "policy_exemption", {}), v.template.name, [])
       : [
         {
@@ -21,9 +19,7 @@ locals {
   )
   initiative_mitigated = flatten([
     for k, v in local.azurerm_management_group_policy_assignment_enterprise_scale : [
-      # reverse(split("/", v.scope_id))[0] # archetype_id
       for overwrite_key, overwrite_value in
-      # lookup archetype_id --> policy_exemption --> policy_name --> this gives a list of all the exemption from this policy
       lookup(lookup(lookup(var.archetype_config_overrides, reverse(split("/", v.scope_id))[0], {}), "initiative_exemption", {}), v.template.name, []) : [
         for overwrite in overwrite_value : [
           {

--- a/resources.policy_exemption.tf
+++ b/resources.policy_exemption.tf
@@ -1,0 +1,59 @@
+resource "azurerm_resource_group_policy_exemption" "policy_mitigated_by_overwrite" {
+  for_each             = { for idx, val in local.policy_mitigated : idx => val if val.is_resource_group }
+  name                 = "caf-mitigated-${each.key}-${each.value.name}"
+  resource_group_id    = each.value.overwrite_id
+  policy_assignment_id = each.value.policy_assignment_id
+  metadata             = each.value.metadata
+  exemption_category   = "Mitigated"
+}
+
+resource "azurerm_subscription_policy_exemption" "policy_mitigated_by_overwrite" {
+  for_each             = { for idx, val in local.policy_mitigated : idx => val if val.is_subscription }
+  name                 = "caf-mitigated-${each.key}-${each.value.name}"
+  subscription_id      = each.value.overwrite_id
+  policy_assignment_id = each.value.policy_assignment_id
+  metadata             = each.value.metadata
+  exemption_category   = "Mitigated"
+}
+
+# if it is neither a subscription nor a resource group, it must be a resource
+resource "azurerm_resource_policy_exemption" "policy_mitigated_by_overwrite" {
+  for_each             = { for idx, val in local.policy_mitigated : idx => val if !val.is_subscription && !val.is_resource_group }
+  name                 = "caf-mitigated-${each.key}-${each.value.name}"
+  resource_id          = each.value.overwrite_id
+  policy_assignment_id = each.value.policy_assignment_id
+  metadata             = each.value.metadata
+  exemption_category   = "Mitigated"
+}
+
+
+resource "azurerm_resource_group_policy_exemption" "initiative_mitigated_by_overwrite" {
+  for_each                        = { for idx, val in local.initiative_mitigated : idx => val if val.is_resource_group }
+  name                            = "caf-mitigated-${each.key}-${each.value.name}"
+  resource_group_id               = each.value.overwrite_id
+  policy_assignment_id            = each.value.policy_assignment_id
+  metadata                        = each.value.metadata
+  exemption_category              = "Mitigated"
+  policy_definition_reference_ids = each.value.policy_definition_reference_ids
+}
+
+resource "azurerm_subscription_policy_exemption" "initiative_mitigated_by_overwrite" {
+  for_each                        = { for idx, val in local.initiative_mitigated : idx => val if val.is_subscription }
+  name                            = "caf-mitigated-${each.key}-${each.value.name}"
+  subscription_id                 = each.value.overwrite_id
+  policy_assignment_id            = each.value.policy_assignment_id
+  metadata                        = each.value.metadata
+  exemption_category              = "Mitigated"
+  policy_definition_reference_ids = each.value.policy_definition_reference_ids
+}
+
+# if it is neither a subscription nor a resource group, it must be a resource
+resource "azurerm_resource_policy_exemption" "initiative_mitigated_by_overwrite" {
+  for_each                        = { for idx, val in local.initiative_mitigated : idx => val if !val.is_subscription && !val.is_resource_group }
+  name                            = "caf-mitigated-${each.key}-${each.value.name}"
+  resource_id                     = each.value.overwrite_id
+  policy_assignment_id            = each.value.policy_assignment_id
+  metadata                        = each.value.metadata
+  exemption_category              = "Mitigated"
+  policy_definition_reference_ids = each.value.policy_definition_reference_ids
+}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

Add policy exemptions to the CAF using the `archetype_config_overrides` as discussed in #277 . It is possible to exempt a scope (either subscription, resource group or individual resources) from a policy/initiative or from one policy within an initiative. The exemption must be defined at the scope the policy is assigned.

```hcl

locals {
  archetype_config_overrides = {
    escorp = {
      # exempt a resource from a policy/initiative completely
      policy_exemption = {
        Deploy-MDFC-Config     = [
          "/subscriptions/00000000-0000-0000-0000-000000000000", # to exempt a complete subscription
          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ActivityLogAlerts", # to exempt a resource group
          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/demo-stephi", # to exempt a resource group
          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/demo-stephi/providers/Microsoft.Network/virtualNetworks/aks-network", # to exempt a specific resource
        ]
        Deploy-VM-Monitoring   = [
          "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/demo-stephi", # to exempt a resource group
        ]
      }
      # to exempt from specific policies within an initiative
      initiative_exemption = {
        Deploy-VMSS-Monitoring = { # initiative name
          LogAnalyticsExtension_Linux_VMSS_Deploy = [ # policy name
            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/demo-stephi", # to exempt a resource group
            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/Default-ActivityLogAlerts", # to exempt a resource group
            ]
            DependencyAgentExtension_Windows_VMSS_Deploy= [          
            "/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/demo-stephi", # to exempt a resource group
            ]
        }
      }
    }

```

For every entry in the configuration above, one exemption is created.

### #There are several limitations to discuss:
1. policy exemptions have a couple of parameters. It is possible to set them to "mitigated" or "waiver", the exemption can be temporary, a description can be added. I did not want to make the overwrite config to complex, so I always set it to mitigated, no expiration date, no description. I set the names for the exemptions to "caf-mitigated-{ID}-{assignmentName}".
2.  It is possible to write resourceSelectors to identify the resources which should be exempted. Those are more flexible than what is currently possible in the overwrite config where every subscription/resourcegroup/resource needs to be defined. 
3. In the portal, it is possible to create one exemption with multiple resources. This could be particularly interesting for the initiatives, e.g. by grouping all exemptions from one policy within the initiative in one exemption. I am not sure if this would make it easier to understand or not.
4. The naming in the `archetype_config_overrides` is confusing, as the `policy_exemption` parameter actually works for both policies and initiatives (it makes a complete exemption), while the `initiative_exemption` parameter gives the possibility to select policies within the initiative to exempt from.

### Breaking Changes

No breaking changes, as this is an optional configuration.

## Testing Evidence

The exemptions are visible in the portal as expected.

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure. 
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
