### PR TITLE
Feature Request - Update Policy Assignment Code to use parameters fro…

### DIFF
--- a/resources.policy_assignments.tf
+++ b/resources.policy_assignments.tf
@@ -48,6 +48,25 @@ resource "azurerm_management_group_policy_assignment" "enterprise_scale" {
     }
   }
 
+  # Optional Resource selectors block
+  # Only one of "in" or "not_in" should be used
+  # Each kind can be used only once
+
+  dynamic "resource_selectors" {
+    for_each = try({ for i, resourceSelector in each.value.template.properties.resourceSelectors : i => resourceSelector }, local.empty_map)
+    content {
+      name = resource_selectors.value.name
+      dynamic "selectors" {
+        for_each = try({ for i, selector in resource_selectors.value.selectors : i => selector }, local.empty_map)
+        content {
+          in     = try(selectors.value.in, local.empty_list)
+          kind   = try(selectors.value.kind)
+          not_in = try(selectors.value.not_in, local.empty_list)
+        }
+      }
+    }
+  }
+
   # Optional Non-compliance messages
   # The mesage will have the placeholder replaced with 'must' or 'should' by default dependent on the enforcement mode
   # The language can the altered or localised using the variables


### PR DESCRIPTION
…m api version 2022-06-01 #660

<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Add dynamic resourceSelectors block as per [Feature Request - Update Policy Assignment Code to use parameters from api version 2022-06-01](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/660#top)
#660 

 ## This PR fixes/adds/changes/removes

1. Adds dynamic resourceSelectors block


### Breaking Changes

1. Not found


## Testing Evidence

![image](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/assets/43970603/f6effc71-05f3-4b31-bbe8-7e31764acdf4)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [] Updated relevant and associated documentation.
