### PR TITLE
Bug: Duplicate Object Key Firewall PIP

### DIFF
--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -889,7 +889,7 @@ locals {
       null
     )
   }
-    azfw_mgmt_pip_zones = {
+  azfw_mgmt_pip_zones = {
     for location in local.hub_network_locations :
     location =>
     try(

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -859,7 +859,7 @@ locals {
   azfw_mgmt_pip_name = {
     for location in local.hub_network_locations :
     location =>
-    try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].name,
+    try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].mgmt_name,
     "${local.azfw_name[location]}-mgmt-pip")
   }
   azfw_pip_resource_id_prefix = {
@@ -882,6 +882,18 @@ locals {
     location =>
     try(
       local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].zones,
+      length(local.azfw_zones[location]) == 1 ?
+      local.azfw_zones[location] :
+      length(local.azfw_zones[location]) >= 2 ?
+      ["1", "2", "3"] :
+      null
+    )
+  }
+    azfw_mgmt_pip_zones = {
+    for location in local.hub_network_locations :
+    location =>
+    try(
+      local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].mgmt_zones,
       length(local.azfw_zones[location]) == 1 ?
       local.azfw_zones[location] :
       length(local.azfw_zones[location]) >= 2 ?
@@ -1050,16 +1062,16 @@ locals {
                 name                    = local.azfw_mgmt_pip_name[location]
                 resource_group_name     = local.resource_group_names_by_scope_and_location["connectivity"][location]
                 location                = location
-                zones                   = local.azfw_pip_zones[location]
-                sku                     = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].sku, "Standard")
-                allocation_method       = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].allocation_method, "Static")
-                ip_version              = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].ip_version, null)
-                idle_timeout_in_minutes = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].idle_timeout_in_minutes, null)
-                domain_name_label       = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].domain_name_label, null)
-                reverse_fqdn            = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].reverse_fqdn, null)
-                public_ip_prefix_id     = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].public_ip_prefix_id, null)
-                ip_tags                 = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].ip_tags, null)
-                tags                    = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].tags, local.tags)
+                zones                   = local.azfw_mgmt_pip_zones[location]
+                sku                     = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].mgmt_sku, "Standard")
+                allocation_method       = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].mgmt_allocation_method, "Static")
+                ip_version              = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].mgmt_ip_version, null)
+                idle_timeout_in_minutes = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].mgmt_idle_timeout_in_minutes, null)
+                domain_name_label       = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].mgmt_domain_name_label, null)
+                reverse_fqdn            = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].mgmt_reverse_fqdn, null)
+                public_ip_prefix_id     = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].mgmt_public_ip_prefix_id, null)
+                ip_tags                 = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].mgmt_ip_tags, null)
+                tags                    = try(local.custom_settings.azurerm_public_ip["connectivity_firewall"][location].mgmt_tags, local.tags)
               }]
             )
           )

--- a/tests/modules/test_001_baseline/baseline_values.json
+++ b/tests/modules/test_001_baseline/baseline_values.json
@@ -1567,7 +1567,7 @@
               ],
               "not_scopes": [],
               "overrides": [],
-              "parameters": "{\"logAnalyticsWorkspaceId\":{\"value\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups/root-id-1-mgmt/providers/microsoft.operationalinsights/workspaces/root-id-1-la\"}}",
+              "parameters": "{\"logAnalyticsWorkspaceId\":{\"value\":\"/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/root-id-1-mgmt/providers/microsoft.operationalinsights/workspaces/root-id-1-la\"}}",
               "policy_definition_id": "/providers/Microsoft.Authorization/policyDefinitions/25da7dfb-0666-4a15-a8f5-402127efd8bb",
               "resource_selectors": [],
               "timeouts": null

--- a/tests/modules/test_002_add_custom_core/baseline_values.json
+++ b/tests/modules/test_002_add_custom_core/baseline_values.json
@@ -2193,7 +2193,7 @@
               ],
               "not_scopes": [],
               "overrides": [],
-              "parameters": "{\"logAnalyticsWorkspaceId\":{\"value\":\"/subscriptions/a9d8bda7-a341-4fe2-bfbf-61145868379e/resourceGroups/root-id-1-mgmt/providers/microsoft.operationalinsights/workspaces/root-id-1-la\"}}",
+              "parameters": "{\"logAnalyticsWorkspaceId\":{\"value\":\"/subscriptions/a9d8bda7-a341-4fe2-bfbf-61145868379e/resourcegroups/root-id-1-mgmt/providers/microsoft.operationalinsights/workspaces/root-id-1-la\"}}",
               "policy_definition_id": "/providers/Microsoft.Authorization/policyDefinitions/25da7dfb-0666-4a15-a8f5-402127efd8bb",
               "resource_selectors": [],
               "timeouts": null

--- a/tests/modules/test_003_add_mgmt_conn/baseline_values.json
+++ b/tests/modules/test_003_add_mgmt_conn/baseline_values.json
@@ -8493,7 +8493,7 @@
               ],
               "not_scopes": [],
               "overrides": [],
-              "parameters": "{\"logAnalyticsWorkspaceId\":{\"value\":\"/subscriptions/a9d8bda7-a341-4fe2-bfbf-61145868379e/resourceGroups/root-id-1-mgmt/providers/microsoft.operationalinsights/workspaces/root-id-1-la\"}}",
+              "parameters": "{\"logAnalyticsWorkspaceId\":{\"value\":\"/subscriptions/a9d8bda7-a341-4fe2-bfbf-61145868379e/resourcegroups/root-id-1-mgmt/providers/microsoft.operationalinsights/workspaces/root-id-1-la\"}}",
               "policy_definition_id": "/providers/Microsoft.Authorization/policyDefinitions/25da7dfb-0666-4a15-a8f5-402127efd8bb",
               "resource_selectors": [],
               "timeouts": null


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Fixing bug that causes error when attempting to use custom naming for Public Ips when using the Azure Firewall Basic SKU. 

## This PR fixes/adds/changes/removes

1. Adds complete customization for Azure Firewall Management PIP.
2. Fixes duplicate object key error.


### Breaking Changes
No breaking changes.

## Testing Evidence

Test settings: 
<img width="203" alt="image" src="https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/assets/77284962/59aa8dbd-2feb-4f55-b73c-429fa0720395">

Terraform Plan: 
Azure Firewall Main PIP, 
<img width="592" alt="image" src="https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/assets/77284962/2ded677d-6489-48ae-b858-7cbd506e9910">
Azure Firewall Management PIP, 
<img width="619" alt="image" src="https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/assets/77284962/ee3b10e2-06df-4e15-8fd1-b33f9eb79a69">


## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
