### PR TITLE
fix parameter naming

### DIFF
--- a/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_deploy_private_dns_zones.tmpl.json
+++ b/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_deploy_private_dns_zones.tmpl.json
@@ -506,7 +506,7 @@
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/06695360-db88-47f6-b976-7500d4297475",
         "parameters": {
           "privateDnsZoneId": {
-            "value": "[parameters('azureFileprivateDnsZoneId')]"
+            "value": "[parameters('azureFilePrivateDnsZoneId')]"
           },
           "effect": {
             "value": "[parameters('effect')]"


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

see issue #795, there is a small `p` which should be a capital `P` in `azureFilePrivateDnsZoneId`.

## This PR fixes/adds/changes/removes

1. fixes initiative to deploy private endpoints, which did not work for file sync previously.

### Breaking Changes

None

## Testing Evidence

I tested it locally and the parameter is set correctly after fixing the syntax error.

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation. --> no update necessary
