### PR TITLE
Docs: Fix documentation for recent policy updates

### DIFF
--- a/docs/wiki/[Examples]-Expand-built-in-archetype-definitions.md
+++ b/docs/wiki/[Examples]-Expand-built-in-archetype-definitions.md
@@ -14,17 +14,21 @@ The built-in definition contains the following settings:
 {
   "es_landing_zones": {
     "policy_assignments": [
-      "Deny-IP-Forwarding",
-      "Deny-RDP-From-Internet",
+      "Audit-AppGW-WAF",
+      "Deny-IP-forwarding",
+      "Deny-MgmtPorts-Internet",
+      "Deny-Priv-Esc-AKS",
+      "Deny-Privileged-AKS",
       "Deny-Storage-http",
       "Deny-Subnet-Without-Nsg",
       "Deploy-AKS-Policy",
-      "Deploy-SQL-DB-Auditing",
+      "Deploy-AzSqlDb-Auditing",
+      "Deploy-SQL-Threat",
       "Deploy-VM-Backup",
-      "Deploy-SQL-Security",
-      "Deny-Priv-Escalation-AKS",
-      "Deny-Priv-Containers-AKS",
-      "Deny-http-Ingress-AKS"
+      "Enable-DDoS-VNET",
+      "Enforce-AKS-HTTPS",
+      "Enforce-GR-KeyVault",
+      "Enforce-TLS-SSL"
     ],
     "policy_definitions": [],
     "policy_set_definitions": [],
@@ -162,7 +166,7 @@ In this example, we want to add the policy assignment `"Deny-Resource-Locations"
 
 ### `lib/archetype_exclusion_es_landing_zones.tmpl.json`
 
-In this example, we want to remove the policy assignments `"Deny-Priv-Escalation-AKS"`, `Deny-Priv-Containers-AKS` and `Deny-http-Ingress-AKS` from the built-in archetype `es_landing_zones`
+In this example, we want to remove the policy assignments `"Deny-Priv-Esc-AKS"`, `Deny-Privileged-AKS` and `Deny-Storage-http` from the built-in archetype `es_landing_zones`
 
 - In the `/lib` directory create an `archetype_exclusion_es_landing_zones.tmpl.json` file.
 
@@ -172,9 +176,9 @@ In this example, we want to remove the policy assignments `"Deny-Priv-Escalation
 {
   "exclude_es_landing_zones": {
     "policy_assignments": [
-      "Deny-Priv-Escalation-AKS",
-      "Deny-Priv-Containers-AKS",
-      "Deny-http-Ingress-AKS"
+      "Deny-Priv-Esc-AKS",
+      "Deny-Privileged-AKS",
+      "Deny-Storage-http"
     ],
     "policy_definitions": [],
     "policy_set_definitions": [],


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR updates the examples in the documentation for policy assignment exclusions to include policy assignments that exist since the last major policy refresh.

## This PR fixes/adds/changes/removes

1. #797 

### Breaking Changes

None

## Testing Evidence

N/A documentation only

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
