### PR TITLE
Fix routing intent deployment issue in virtual wan

### DIFF
--- a/resources.virtual_wan.tf
+++ b/resources.virtual_wan.tf
@@ -378,6 +378,7 @@ resource "azurerm_virtual_hub_routing_intent" "virtual_wan" {
 
   # Set explicit dependencies
   depends_on = [
+    azurerm_firewall.virtual_wan,
     azurerm_resource_group.connectivity,
     azurerm_resource_group.virtual_wan,
     azurerm_virtual_wan.virtual_wan,


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

This PR addresses the issue described in the issue #868 - routing_intent does not find the next hop destination when deployed with the azurerm firewall in vhub.


### Breaking Changes

no

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

Before the fix:
```
 API Response:
│ 
│ ----[start]----
│ {"status":"Failed","error":{"code":"InvalidNextHop","message":"The next hop '/subscriptions/xxxxxx/resourceGroups/connectivity/providers/Microsoft.Network/azureFirewalls/fw-hub-japaneast' in route/policy 'routing-intent-policy-all' in the resource '/subscriptions/xxxxxx/resourceGroups/connectivity/providers/Microsoft.Network/virtualHubs/hub-japaneast/routingIntent/routingintent-japaneast' is invalid.","details":[]}}
│ -----[end]-----
│ 
│ 
│   with module.alz.azurerm_virtual_hub_routing_intent.virtual_wan["/subscriptions/xxxxxxx/resourceGroups/connectivity/providers/Microsoft.Network/virtualHubs/hub-japaneast/routingintent-japaneast"],
│   on ../../alz/resources.virtual_wan.tf line 364, in resource "azurerm_virtual_hub_routing_intent" "virtual_wan":
│  364: resource "azurerm_virtual_hub_routing_intent" "virtual_wan" {
│ 
│ creating Routing Intent (Subscription: "xxxxxxx"
│ Resource Group Name: "connectivity"
│ Virtual Hub Name: "hub-japaneast"
│ Routing Intent Name: "routingintent-japaneast"): polling after RoutingIntentCreateOrUpdate: polling failed: the Azure API returned the following error:
│ 
│ Status: "InvalidNextHop"
│ Code: ""
│ Message: "The next hop '/subscriptions/xxxxxxx/resourceGroups/connectivity/providers/Microsoft.Network/azureFirewalls/fw-hub-japaneast' in route/policy 'routing-intent-policy-all' in
│ the resource '/subscriptions/xxxxxx/resourceGroups/connectivity/providers/Microsoft.Network/virtualHubs/hub-japaneast/routingIntent/routingintent-japaneast' is invalid."
│ Activity Id: ""
│ 
│ ---
```

With the depends_on we can see the firewall got deployed before the routing intent:
```
module.alz.azurerm_firewall.virtual_wan["/subscriptions/xxxxx/resourceGroups/connectivity/providers/Microsoft.Network/azureFirewalls/fw-hub-southeastasia"]: Creation complete after 3m44s [id=/subscriptions/xxxxxx/resourceGroups/connectivity/providers/Microsoft.Network/azureFirewalls/fw-hub-southeastasia]
module.alz.azurerm_virtual_hub_routing_intent.virtual_wan["/subscriptions/xxxxxx0/resourceGroups/connectivity/providers/Microsoft.Network/virtualHubs/hub-southeastasia/routingintent-southeastasia"]: Creating...
module.alz.azurerm_virtual_hub_routing_intent.virtual_wan["/subscriptions/xxxxxx/resourceGroups/connectivity/providers/Microsoft.Network/virtualHubs/hub-southeastasia/routingintent-southeastasia"]: Still creating... [10s elapsed]

....

module.alz.azurerm_virtual_hub_routing_intent.virtual_wan["/subscriptions/xxxx/resourceGroups/connectivity/providers/Microsoft.Network/virtualHubs/hub-southeastasia/cloudlab-routingintent-southeastasia"]: Creation complete after 6m24s [id=/subscriptions/xxxx/resourceGroups/connectivity/providers/Microsoft.Network/virtualHubs/hub-southeastasia/routingIntent/routingintent-southeastasia]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
