### PR TITLE
feat(connectivity): custom Settings for Virtual Hub connection names

### DIFF
--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1819,24 +1819,6 @@ locals {
 # Configuration settings for resource type:
 #  - azurerm_virtual_hub_connection
 locals {
-  virtual_hub_connection_name = {
-    for location, virtual_hub_config in local.virtual_hubs_by_location :
-    location => {
-      for spoke_resource_id in virtual_hub_config.config.spoke_virtual_network_resource_ids :
-      spoke_resource_id => try(
-        local.custom_settings.azurerm_virtual_hub_connection["virtual_wan"][location][spoke_resource_id].name,
-        "peering-${uuidv5("url", spoke_resource_id)}"
-      )
-    }
-  }
-  virtual_hub_connection_resource_id = {
-    for location, virtual_hub_config in local.virtual_hubs_by_location :
-    location => {
-      for spoke_resource_id, hub_connection_name in local.virtual_hub_connection_name[location] :
-      spoke_resource_id =>
-      "${local.virtual_hub_resource_id[location]}/hubVirtualNetworkConnections/${hub_connection_name}"
-    }
-  }
   azurerm_virtual_hub_connection = flatten(
     [
       for location, virtual_hub_config in local.virtual_hubs_by_location :
@@ -1844,10 +1826,16 @@ locals {
         for spoke_resource_id in distinct(concat(virtual_hub_config.config.spoke_virtual_network_resource_ids, virtual_hub_config.config.secure_spoke_virtual_network_resource_ids)) :
         {
           # Resource logic attributes
-          resource_id       = local.virtual_hub_connection_resource_id[location][spoke_resource_id]
+          resource_id = try(
+            "${local.virtual_hub_resource_id[location]}/hubVirtualNetworkConnections/${local.custom_settings.azurerm_virtual_hub_connection["virtual_wan"][location][spoke_resource_id].name}",
+            "${local.virtual_hub_resource_id[location]}/hubVirtualNetworkConnections/peering-${uuidv5("url", spoke_resource_id)}"
+          )
           managed_by_module = local.deploy_virtual_hub_connection[location]
           # Resource definition attributes
-          name                      = local.virtual_hub_connection_name[location][spoke_resource_id]
+          name = try(
+            local.custom_settings.azurerm_virtual_hub_connection["virtual_wan"][location][spoke_resource_id].name,
+            "peering-${uuidv5("url", spoke_resource_id)}"
+          )
           virtual_hub_id            = local.virtual_hub_resource_id[location]
           remote_virtual_network_id = spoke_resource_id
           # Optional definition attributes


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Been an outstanding request for a while but finally got a chance to look at this properly. The additional capability will allow users to override a Virtual Hub Virtual Network Connection name. The logic is the same as what was added for hub/spoke peerings via https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pull/401

## This PR fixes/adds/changes/removes

1.  https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/633

## Testing Evidence

Evidence from local run:

Virtual Network Resource IDs added to relevant arrays withing settings.connectivity.tf:
![image](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/assets/42775203/d6df23a7-915a-4cb4-9c49-31da789dcd2b)
Without a custom setting we get a randomly generated connection name:
![image](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/assets/42775203/3b2f4e0b-0317-4a56-90e9-2495f8b3bea9)
With the custom setting for the target virtual network resource id added to the settings.connectivity.tf:
![image](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/assets/42775203/057b9afd-3e2d-495b-99f5-5a42fb9d3cbd)
The random name is overridden:
![image](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/assets/42775203/83523099-15a3-46a3-97e4-0f11406faa2a)
Portal Views following deployment:
![image](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/assets/42775203/9e683122-c18b-43da-ad84-df8c8dfe74c8)
![image](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/assets/42775203/7be31d81-0316-41a5-8171-ef99213dc957)

Adding a custom setting to a currently connected virtual network or changing the name will destroy and recreate the connection. Terraform waits for the destroy to complete before re-adding the connection.
![image](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/assets/42775203/6e95dc9f-9b4f-4034-808d-b42c889f0c11)

## As part of this Pull Request I have

- [X] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [X] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [X] Performed testing and provided evidence.
- [X] Updated relevant and associated documentation.
