### PR TITLE
fix: posgres flexible diagnostic policy

### DIFF
--- a/modules/archetypes/lib/policy_definitions/policy_definition_es_deploy_diagnostics_postgresql.json
+++ b/modules/archetypes/lib/policy_definitions/policy_definition_es_deploy_diagnostics_postgresql.json
@@ -9,7 +9,7 @@
     "displayName": "Deploy Diagnostic Settings for Database for PostgreSQL to Log Analytics workspace",
     "description": "Deploys the diagnostic settings for Database for PostgreSQL to stream to a Log Analytics workspace when any Database for PostgreSQL which is missing this diagnostic settings is created or updated. The Policy will set the diagnostic with all metrics and category enabled",
     "metadata": {
-      "version": "2.0.0",
+      "version": "2.0.1",
       "category": "Monitoring",
       "source": "https://github.com/Azure/Enterprise-Scale/",
       "alzCloudEnvironments": [
@@ -162,11 +162,15 @@
                         }
                       ],
                       "logs": [
-                        {
-                          "category": "PostgreSQLLogs",
-                          "enabled": "[parameters('logsEnabled')]"
-                        }
-                      ]
+                          {
+                            "categoryGroup": "allLogs",
+                            "enabled": "[parameters('logsEnabled')]"
+                          },
+                          {
+                            "categoryGroup": "audit",
+                            "enabled": "[parameters('logsEnabled')]"
+                          }                   
+                        ]
                     }
                   },
                   {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

## Overview/Summary

Currently the deployment does not remediate the policy so that the rules are met.
This updates the postgres diagnostics policy in line with the new Category groups, so that after a deployment, the rules are met. 

## Testing Evidence

Deployments are successful in my environment, and my resources are now compliant with the policy 
![image](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/assets/54796226/5d3d42ab-b510-4629-8c90-873f2939d754)


## As part of this Pull Request I have

I came across this independently, but I believe it addresses https://github.com/Azure/Enterprise-Scale/issues/1309

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
