### PR TITLE
Add AzureBastionSubnet into exclusion of subnet with nsg policy

### DIFF
--- a/modules/archetypes/lib/policy_definitions/policy_definition_es_deny_subnet_without_nsg.json
+++ b/modules/archetypes/lib/policy_definitions/policy_definition_es_deny_subnet_without_nsg.json
@@ -41,7 +41,8 @@
         "defaultValue": [
           "GatewaySubnet",
           "AzureFirewallSubnet",
-          "AzureFirewallManagementSubnet"
+          "AzureFirewallManagementSubnet",
+          "AzureBastionSubnet"
         ]
       }
     },


### PR DESCRIPTION
This PR adds

1. AzureBastionSubnet into the exclusion list of deny subnet without NSG policy.

As other special subnets, Azure does not allow any NSG to be associated with AzureBastionSubnet.