### PR TITLE
Fix GITHUB_TOKEN Permissions for Policy Sync Workflow due to recent Changes 

### DIFF
--- a/.github/workflows/update-policy.yml
+++ b/.github/workflows/update-policy.yml
@@ -19,6 +19,9 @@ jobs:
   update-templates:
     name: Update Library Templates
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Local repository checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
This pull request includes a modification to the `.github/workflows/update-policy.yml` file. The change adds permissions for `contents` and `pull-requests` to the `update-templates` job, granting write access. This will allow the job to update library templates by writing to the repository's contents and creating or modifying pull requests.