### PR TITLE
fix(outputs): set Log Analytics workspaces and Automation Accounts as senstive outputs

### DIFF
--- a/outputs.tf
+++ b/outputs.tf
@@ -86,6 +86,7 @@ output "azurerm_log_analytics_workspace" {
     management = azurerm_log_analytics_workspace.management
   }
   description = "Returns the configuration data for all Log Analytics workspaces created by this module."
+  sensitive   = true
 }
 
 # The following output is used to ensure all Log Analytics
@@ -104,6 +105,7 @@ output "azurerm_automation_account" {
     management = azurerm_automation_account.management
   }
   description = "Returns the configuration data for all Automation Accounts created by this module."
+  sensitive   = true
 }
 
 # The following output is used to ensure all Log Analytics


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Set the outputs for Log Analytics workspaces and Automation Accounts to sensitive

## This PR fixes/adds/changes/removes

- Fixes #892 

### Breaking Changes

1. None

## Testing Evidence

- I can Terraform plan/apply with no issue

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
