### PR TITLE
add databricks as service in connectivity

### DIFF
--- a/README.md
+++ b/README.md
@@ -534,6 +534,7 @@ object({
             azure_database_for_mariadb_server    = optional(bool, true)
             azure_database_for_mysql_server      = optional(bool, true)
             azure_database_for_postgresql_server = optional(bool, true)
+            azure_databricks                     = optional(bool, true)
             azure_digital_twins                  = optional(bool, true)
             azure_event_grid_domain              = optional(bool, true)
             azure_event_grid_topic               = optional(bool, true)

--- a/docs/wiki/[Examples]-Deploy-Connectivity-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Connectivity-Resources-With-Custom-Settings.md
@@ -306,6 +306,7 @@ locals {
             azure_database_for_mariadb_server    = true
             azure_database_for_mysql_server      = true
             azure_database_for_postgresql_server = true
+            azure_databricks                     = true
             azure_digital_twins                  = true
             azure_event_grid_domain              = true
             azure_event_grid_topic               = true

--- a/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources-With-Custom-Settings.md
@@ -292,6 +292,7 @@ locals {
             azure_database_for_mariadb_server    = true
             azure_database_for_mysql_server      = true
             azure_database_for_postgresql_server = true
+            azure_databricks                     = true
             azure_digital_twins                  = true
             azure_event_grid_domain              = true
             azure_event_grid_topic               = true

--- a/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources.md
+++ b/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources.md
@@ -180,6 +180,7 @@ module "enterprise_scale" {
             azure_database_for_mariadb_server    = true
             azure_database_for_mysql_server      = true
             azure_database_for_postgresql_server = true
+            azure_databricks                     = true
             azure_digital_twins                  = true
             azure_event_grid_domain              = true
             azure_event_grid_topic               = true

--- a/docs/wiki/[Examples]-Deploy-ZT-Network.md
+++ b/docs/wiki/[Examples]-Deploy-ZT-Network.md
@@ -210,6 +210,7 @@ locals {
             azure_database_for_mariadb_server    = true
             azure_database_for_mysql_server      = true
             azure_database_for_postgresql_server = true
+            azure_databricks                     = true
             azure_digital_twins                  = true
             azure_event_grid_domain              = true
             azure_event_grid_topic               = true

--- a/modules/connectivity/README.md
+++ b/modules/connectivity/README.md
@@ -328,6 +328,7 @@ object({
           azure_database_for_mariadb_server    = optional(bool, true)
           azure_database_for_mysql_server      = optional(bool, true)
           azure_database_for_postgresql_server = optional(bool, true)
+          azure_databricks                     = optional(bool, true)
           azure_digital_twins                  = optional(bool, true)
           azure_event_grid_domain              = optional(bool, true)
           azure_event_grid_topic               = optional(bool, true)

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1457,6 +1457,7 @@ locals {
     azure_database_for_mariadb_server    = ["privatelink.mariadb.database.azure.com"]
     azure_database_for_mysql_server      = ["privatelink.mysql.database.azure.com"]
     azure_database_for_postgresql_server = ["privatelink.postgres.database.azure.com"]
+    azure_databricks                     = ["privatelink.azuredatabricks.net"]
     azure_digital_twins                  = ["privatelink.digitaltwins.azure.net"]
     azure_event_grid_domain              = ["privatelink.eventgrid.azure.net"]
     azure_event_grid_topic               = ["privatelink.eventgrid.azure.net"]
@@ -1534,6 +1535,7 @@ locals {
     azure_database_for_mariadb_server    = local.empty_string
     azure_database_for_mysql_server      = local.empty_string
     azure_database_for_postgresql_server = local.empty_string
+    azure_databricks                     = local.empty_string
     azure_digital_twins                  = local.empty_string
     azure_event_grid_domain              = local.empty_string
     azure_event_grid_topic               = local.empty_string

--- a/modules/connectivity/variables.tf
+++ b/modules/connectivity/variables.tf
@@ -250,6 +250,7 @@ variable "settings" {
           azure_database_for_mariadb_server    = optional(bool, true)
           azure_database_for_mysql_server      = optional(bool, true)
           azure_database_for_postgresql_server = optional(bool, true)
+          azure_databricks                     = optional(bool, true)
           azure_digital_twins                  = optional(bool, true)
           azure_event_grid_domain              = optional(bool, true)
           azure_event_grid_topic               = optional(bool, true)

--- a/variables.tf
+++ b/variables.tf
@@ -363,6 +363,7 @@ variable "configure_connectivity_resources" {
             azure_database_for_mariadb_server    = optional(bool, true)
             azure_database_for_mysql_server      = optional(bool, true)
             azure_database_for_postgresql_server = optional(bool, true)
+            azure_databricks                     = optional(bool, true)
             azure_digital_twins                  = optional(bool, true)
             azure_event_grid_domain              = optional(bool, true)
             azure_event_grid_topic               = optional(bool, true)


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

So I've deployed this module recently and was relying on policy to setup dns for private endpoints. Databricks was the only service I couldn't find an existing zone for.

## This PR fixes/adds/changes/removes

1. Add private dns zone for databricks

### Breaking Changes

1. None

## Testing Evidence

I can set this up as a private terraform module and test it but I was hoping you'd have unit tests for it. It's not urgent for me to fix this but I thought I'd raise it as a PR to at least see if there was any reason it wasn't in that I am missing or worth adding.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
