### PR TITLE
feat(connectivity): Add option to set allow_non_virtual_wan_traffic in express route gateway.

### DIFF
--- a/README.md
+++ b/README.md
@@ -450,6 +450,7 @@ object({
               enabled = optional(bool, false)
               config = optional(object({
                 scale_unit = optional(number, 1)
+                allow_non_virtual_wan_traffic = optional(bool, false)
               }), {})
             }), {})
             vpn_gateway = optional(object({

--- a/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources-With-Custom-Settings.md
@@ -180,6 +180,7 @@ locals {
               enabled = true
               config = {
                 scale_unit = 1
+                allow_non_virtual_wan_traffic = false
               }
             }
             vpn_gateway = {

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1338,11 +1338,12 @@ locals {
       resource_id       = local.virtual_hub_express_route_gateway_resource_id[location]
       managed_by_module = local.deploy_virtual_hub_express_route_gateway[location]
       # Resource definition attributes
-      name                = local.virtual_hub_express_route_gateway_name[location]
-      resource_group_name = local.virtual_hub_resource_group_name[location]
-      location            = location
-      virtual_hub_id      = local.virtual_hub_resource_id[location]
-      scale_units         = virtual_hub.config.expressroute_gateway.config.scale_unit
+      name                          = local.virtual_hub_express_route_gateway_name[location]
+      resource_group_name           = local.virtual_hub_resource_group_name[location]
+      location                      = location
+      virtual_hub_id                = local.virtual_hub_resource_id[location]
+      scale_units                   = virtual_hub.config.expressroute_gateway.config.scale_unit
+      allow_non_virtual_wan_traffic = virtual_hub.config.expressroute_gateway.config.allow_non_virtual_wan_traffic
       # Optional definition attributes
       tags = try(local.custom_settings.azurerm_express_route_gateway["virtual_wan"][location].tags, local.tags)
     }

--- a/modules/connectivity/variables.tf
+++ b/modules/connectivity/variables.tf
@@ -165,7 +165,8 @@ variable "settings" {
           expressroute_gateway = optional(object({
             enabled = optional(bool, false)
             config = optional(object({
-              scale_unit = optional(number, 1)
+              scale_unit                    = optional(number, 1)
+              allow_non_virtual_wan_traffic = optional(bool, false)
             }), {})
           }), {})
           vpn_gateway = optional(object({

--- a/resources.virtual_wan.tf
+++ b/resources.virtual_wan.tf
@@ -75,12 +75,12 @@ resource "azurerm_express_route_gateway" "virtual_wan" {
   provider = azurerm.connectivity
 
   # Mandatory resource attributes
-  name                = each.value.template.name
-  resource_group_name = each.value.template.resource_group_name
-  location            = each.value.template.location
-  virtual_hub_id      = each.value.template.virtual_hub_id
-  scale_units         = each.value.template.scale_units
-
+  name                          = each.value.template.name
+  resource_group_name           = each.value.template.resource_group_name
+  location                      = each.value.template.location
+  virtual_hub_id                = each.value.template.virtual_hub_id
+  scale_units                   = each.value.template.scale_units
+  allow_non_virtual_wan_traffic = each.value.template.allow_non_virtual_wan_traffic
   # Optional resource attributes
   tags = each.value.template.tags
 

--- a/tests/modules/settings/settings.connectivity.tf
+++ b/tests/modules/settings/settings.connectivity.tf
@@ -142,7 +142,8 @@ locals {
             expressroute_gateway = {
               enabled = true
               config = {
-                scale_unit = 1
+                scale_unit                    = 1
+                allow_non_virtual_wan_traffic = false
               }
             }
             vpn_gateway = {

--- a/variables.tf
+++ b/variables.tf
@@ -278,7 +278,8 @@ variable "configure_connectivity_resources" {
             expressroute_gateway = optional(object({
               enabled = optional(bool, false)
               config = optional(object({
-                scale_unit = optional(number, 1)
+                scale_unit                    = optional(number, 1)
+                allow_non_virtual_wan_traffic = optional(bool, false)
               }), {})
             }), {})
             vpn_gateway = optional(object({


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Add option to set `allow_non_virtual_wan_traffic` value to `true` or `false` in express route gateway.

## This PR fixes/adds/changes/removes

1. *Give the option to set `allow_non_virtual_wan_traffic` to true in azurerm_express_route_gateway resource*

### Breaking Changes

None 

## Testing Evidence

On the latest azurerm versions ( v3.48.0 and higher ) **azurerm_express_route_gateway** resource has the option to set this value to true. At the time of writing CAF module has no option available .

We saw this issue in our Dev environment during terraform plan :  the value was true so using a newer azurerm version the value goes to false, which is the default. 

```
  # module.vWAN.module.alz_connectivity.azurerm_express_route_gateway.virtual_wan["/subscriptions/xxxxx-xxxx-xxxx-xxxxx-xxxxxxxxxx/resourceGroups/dev-connectivity/providers/Microsoft.Network/expressRouteGateways/dev-ergw-northeurope"] will be updated in-place
  ~ resource "azurerm_express_route_gateway" "virtual_wan" {
      ~ allow_non_virtual_wan_traffic = true -> false
        id                            = "/subscriptions/xxxxx-xxxx-xxxx-xxxxx-xxxxxxxxxx/resourceGroups/dev-connectivity/providers/Microsoft.Network/expressRouteGateways/dev-ergw-northeurope"
        name                          = "dev-ergw-northeurope"
        tags                          = {
            "deployedBy"  = "terraform/azure/caf-enterprise-scale"
            "deployedFor" = "Dev"
        }
```

More info about this option can be found here :   https://github.com/hashicorp/terraform-provider-azurerm/pull/20667

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
