### PR TITLE
docs: update docs for threat_intelligence_allowlist

### DIFF
--- a/docs/wiki/[Examples]-Deploy-Connectivity-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Connectivity-Resources-With-Custom-Settings.md
@@ -206,7 +206,7 @@ locals {
                 base_policy_id                = ""
                 private_ip_ranges             = []
                 threat_intelligence_mode      = ""
-                threat_intelligence_allowlist = []
+                threat_intelligence_allowlist = {}
                 availability_zones = {
                   zone_1 = true
                   zone_2 = true
@@ -255,7 +255,7 @@ locals {
                 base_policy_id                = ""
                 private_ip_ranges             = []
                 threat_intelligence_mode      = ""
-                threat_intelligence_allowlist = []
+                threat_intelligence_allowlist = {}
                 availability_zones = {
                   zone_1 = true
                   zone_2 = true

--- a/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources-With-Custom-Settings.md
+++ b/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources-With-Custom-Settings.md
@@ -200,7 +200,7 @@ locals {
                 base_policy_id                = ""
                 private_ip_ranges             = []
                 threat_intelligence_mode      = ""
-                threat_intelligence_allowlist = []
+                threat_intelligence_allowlist = {}
                 availability_zones = {
                   zone_1 = true
                   zone_2 = true
@@ -243,7 +243,7 @@ locals {
                 base_policy_id                = ""
                 private_ip_ranges             = []
                 threat_intelligence_mode      = ""
-                threat_intelligence_allowlist = []
+                threat_intelligence_allowlist = {}
                 availability_zones = {
                   zone_1 = true
                   zone_2 = true

--- a/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources.md
+++ b/docs/wiki/[Examples]-Deploy-Virtual-WAN-Resources.md
@@ -130,7 +130,7 @@ module "enterprise_scale" {
                 base_policy_id                = ""
                 private_ip_ranges             = []
                 threat_intelligence_mode      = ""
-                threat_intelligence_allowlist = []
+                threat_intelligence_allowlist = {}
                 availability_zones = {
                   zone_1 = true
                   zone_2 = true

--- a/docs/wiki/[Examples]-Deploy-ZT-Network.md
+++ b/docs/wiki/[Examples]-Deploy-ZT-Network.md
@@ -110,7 +110,7 @@ locals {
                 base_policy_id                = ""
                 private_ip_ranges             = []
                 threat_intelligence_mode      = ""
-                threat_intelligence_allowlist = []
+                threat_intelligence_allowlist = {}
                 availability_zones = {
                   zone_1 = true
                   zone_2 = true
@@ -159,7 +159,7 @@ locals {
                 base_policy_id                = ""
                 private_ip_ranges             = []
                 threat_intelligence_mode      = ""
-                threat_intelligence_allowlist = []
+                threat_intelligence_allowlist = {}
                 availability_zones = {
                   zone_1 = true
                   zone_2 = true
@@ -270,7 +270,7 @@ locals {
 
 ### Reference `settings.management.tf`
 
-The below `settings.management.tf` file can be used to declare these variables as local values, containing the custom inputs for the `configure_management_resources` input variables as described above.  
+The below `settings.management.tf` file can be used to declare these variables as local values, containing the custom inputs for the `configure_management_resources` input variables as described above.
 
 Read more about customizing a connectivity deployment in the [Deploy Management Resources with Custom Settings](%5BExamples%5D-Deploy-Management-Resources-With-Custom-Settings) article.
 

--- a/docs/wiki/[User-Guide]-Module-upgrade-guidance.md
+++ b/docs/wiki/[User-Guide]-Module-upgrade-guidance.md
@@ -46,6 +46,7 @@ If jumping multiple release versions, take care to note additional changes docum
 
 Please refer to the following upgrade guides when updating between major release:
 
+- [Upgrade from v5.1.0 to v5.2.0][wiki_upgrade_from_v5_1_0_to_v5_2_0]
 - [Upgrade from v4.2.0 to v5.0.0][wiki_upgrade_from_v4_2_0_to_v5_0_0]
 - [Upgrade from v3.3.0 to v4.0.0][wiki_upgrade_from_v3_3_0_to_v4_0_0]
 - [Upgrade from v2.4.1 to v3.0.0][wiki_upgrade_from_v2_4_1_to_v3_0_0]
@@ -63,6 +64,7 @@ Please refer to the following upgrade guides when updating between major release
 [module_releases]:     https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/releases "Releases - Azure/terraform-azurerm-caf-enterprise-scale"
 
 [wiki_module_releases]:               %5BUser-Guide%5D-Module-Releases "Wiki - [User Guide] Module Releases"
+[wiki_upgrade_from_v5_1_0_to_v5_2_0]: %5BUser-Guide%5D-Upgrade-from-v5.1.0-to-v5.2.0 "Wiki - Upgrade from v5.1.0 to v5.2.0"
 [wiki_upgrade_from_v4_2_0_to_v5_0_0]: %5BUser-Guide%5D-Upgrade-from-v4.2.0-to-v5.0.0 "Wiki - Upgrade from v4.2.0 to v5.0.0"
 [wiki_upgrade_from_v3_3_0_to_v4_0_0]: %5BUser-Guide%5D-Upgrade-from-v3.3.0-to-v4.0.0 "Wiki - Upgrade from v3.3.0 to v4.0.0"
 [wiki_upgrade_from_v2_4_1_to_v3_0_0]: %5BUser-Guide%5D-Upgrade-from-v2.4.1-to-v3.0.0 "Wiki - Upgrade from v2.4.1 to v3.0.0"

--- a/docs/wiki/[User-Guide]-Upgrade-from-v1.1.4-to-v2.0.0.md
+++ b/docs/wiki/[User-Guide]-Upgrade-from-v1.1.4-to-v2.0.0.md
@@ -250,7 +250,7 @@ sku_tier                      = ""
 base_policy_id                = ""
 private_ip_ranges             = []
 threat_intelligence_mode      = ""
-threat_intelligence_allowlist = []
+threat_intelligence_allowlist = {}
 ```
 
 > **IMPORTANT:** If you have updated any connectivity resource settings using the `advanced` configuration object, you will need to update your code to move your settings into this input and ensure you are using the updated naming schema.

--- a/docs/wiki/[User-Guide]-Upgrade-from-v5.1.0-to-v5.2.0.md
+++ b/docs/wiki/[User-Guide]-Upgrade-from-v5.1.0-to-v5.2.0.md
@@ -1,0 +1,25 @@
+<!-- markdownlint-disable first-line-h1 -->
+## Overview
+
+The `v5.2.0` release makes the following breaking changes:
+
+1. The `threat_intelligence_allowlist` data type has changed from `list` to `map`.
+
+### `threat_intelligence_allowlist` data type change
+
+Existing users that define a `threat_intelligence_allowlist` should update their configuration to use the new `map` data type. For using suppling an empty value, use an empty map `{}`.
+
+```hcl
+threat_intelligence_allowlist = {}
+```
+
+**Full Changelog**: [v5.1.0...v5.2.0](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/compare/v5.1.0...v5.2.0)
+
+## Next steps
+
+Take a look at the latest [User Guide](User-Guide) documentation and our [Examples](Examples) to understand the latest module configuration options, and review your implementation against the changes documented on this page.
+
+## Need help?
+
+If you're running into problems with the upgrade, please let us know via the [GitHub Issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues).
+We will do our best to point you in the right direction.


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

The `threat_intelligence_allowlist` data type was updated in 5.2.0 resulting in a breaking change for some users that was not properly identified.

## This PR fixes/adds/changes/removes

- #922 

### Breaking Changes

None

## Testing Evidence

Docs only

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
