### PR TITLE
Added hub_routing_preference to connectivity advanced configuration

### DIFF
--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1255,8 +1255,9 @@ locals {
       resource_group_name = local.virtual_hub_resource_group_name[location]
       location            = location
       # Optional definition attributes
-      sku            = coalesce(virtual_hub.config.sku, "Standard")
-      address_prefix = virtual_hub.config.address_prefix
+      sku                    = coalesce(virtual_hub.config.sku, "Standard")
+      address_prefix         = virtual_hub.config.address_prefix
+      hub_routing_preference = try(local.custom_settings.azurerm_virtual_hub["virtual_wan"][location].hub_routing_preference, "ExpressRoute")
       virtual_wan_id = length(local.existing_virtual_wan_resource_id) > 0 ? local.existing_virtual_wan_resource_id : (
         length(local.virtual_wan_locations) > 0 ?
         lookup(local.virtual_wan_resource_id, local.virtual_wan_locations[0], null) :

--- a/resources.virtual_wan.tf
+++ b/resources.virtual_wan.tf
@@ -45,10 +45,11 @@ resource "azurerm_virtual_hub" "virtual_wan" {
   location            = each.value.template.location
 
   # Optional resource attributes
-  sku            = each.value.template.sku
-  address_prefix = each.value.template.address_prefix
-  virtual_wan_id = each.value.template.virtual_wan_id
-  tags           = each.value.template.tags
+  sku                    = each.value.template.sku
+  address_prefix         = each.value.template.address_prefix
+  hub_routing_preference = each.value.template.hub_routing_preference
+  virtual_wan_id         = each.value.template.virtual_wan_id
+  tags                   = each.value.template.tags
 
   # Dynamic configuration blocks
   dynamic "route" {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR adds the hub_routing_preference option to the advanced configuration section of azurerm_virtual_hub. 
The default value is the same as for the azurerm provider ("ExpressRoute") so by default no changes will occur when upgrading.
There doesn't seem to be documentation for advanced configs that needs to be updated, let me know if I just missed it and I will update it.

This PR relates to issue https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/861

See azurerm documentation for this option [here](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_hub#hub_routing_preference)

## This PR fixes/adds/changes/removes

1. Adds hub_routing_preference option

### Breaking Changes

## Testing Evidence
In a local test I've modified the custom_settings_by_resource_type block of `tests/modules/settings/settings.connectivity.tf` to include the following:
```
azurerm_virtual_hub = {
  virtual_wan = {
    (var.primary_location) = {
      hub_routing_preference = "ASPath"
    }
  }
}
```
Planning `tests/modules/test_003_add_mgmt_conn` will show that the hub_routing_preference for the primary location hub has changed accordingly and that the secondary location hub maintains it's default configuration "ExpressRoute":
![image](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/assets/106068259/7806ad21-7c0c-423b-9298-be9b66003e36)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
