### PR TITLE
Fix example uami issue

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,3 +53,4 @@ tests/modules/test_local
 **/super-linter.log
 .vscode/launch.json
 .github/scripts/Template.Parser.Cli.exe
+examples/400-multi-with-orchestration/*.auto.tfvars

--- a/examples/400-multi-with-orchestration/modules/core/lib/policy_assignment_es_deploy_vmss_monitoring.tmpl.json.tftpl
+++ b/examples/400-multi-with-orchestration/modules/core/lib/policy_assignment_es_deploy_vmss_monitoring.tmpl.json.tftpl
@@ -1,5 +1,5 @@
 ${jsonencode(
-  {
+{
   "type": "Microsoft.Authorization/policyAssignments",
   "apiVersion": "2022-06-01",
   "name": "Deploy-VMSS-Monitoring",
@@ -14,7 +14,7 @@ ${jsonencode(
   "properties": {
     "description": "Enable Azure Monitor for the Virtual Machine Scale Sets in the specified scope (Management group, Subscription or resource group). Takes Log Analytics workspace as parameter. Note: if your scale set upgradePolicy is set to Manual, you need to apply the extension to the all VMs in the set by calling upgrade on them. In CLI this would be az vmss update-instances.",
     "displayName": "Enable Azure Monitor for Virtual Machine Scale Sets",
-    "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/75714362-cae7-409e-9b99-a8e5075b7fad",
+    "policyDefinitionId": "/providers/Microsoft.Authorization/policySetDefinitions/f5bf694c-cca7-4033-b883-3a23327d5485",
     "enforcementMode": "Default",
     "nonComplianceMessages": [
       {
@@ -22,8 +22,23 @@ ${jsonencode(
       }
     ],
     "parameters": {
-      "logAnalytics_1": {
-        "value": "/subscriptions/00000000-0000-0000-0000-000000000000/resourcegroups/${root_scope_id}-mgmt/providers/Microsoft.OperationalInsights/workspaces/${root_scope_id}-la"
+      "dcrResourceId": {
+        "value": "${azure_monitor_data_collection_rule_vm_insights_resource_id}"
+      },
+      "bringYourOwnUserAssignedManagedIdentity": {
+        "value": true
+      },
+      "restrictBringYourOwnUserAssignedIdentityToSubscription": {
+        "value": false
+      },
+      "userAssignedIdentityResourceId": {
+        "value": "${user_assigned_managed_identity_resource_id}"
+      },
+      "enableProcessesAndDependencies": {
+        "value": true
+      },
+      "scopeToSupportedImages": {
+        "value": false
       }
     },
     "scope": "${current_scope_resource_id}",

--- a/examples/400-multi-with-orchestration/template_file_variables.auto.tfvars
+++ b/examples/400-multi-with-orchestration/template_file_variables.auto.tfvars
@@ -1,7 +1,0 @@
-template_file_variables = {
-  userAssignedIdentities = {
-    "Deploy-VMSS-Monitoring" = [
-      "/subscriptions/dfa7c595-ef32-42e4-be9d-68fb9ef0c853/resourceGroups/msi/providers/Microsoft.ManagedIdentity/userAssignedIdentities/ms1"
-    ]
-  }
-}


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

The UAMI for policy int he example code fails due to hard coded resource id. This fixes it by creating the UAMI as part of the example.

## This PR fixes/adds/changes/removes

N/A

### Breaking Changes

None, example only

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
