### PR TITLE
Add possibility to manually set privatelink partition ids for azure static apps

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -75,12 +75,13 @@ module "connectivity_resources" {
   tags     = local.connectivity_resources_tags
 
   # Optional input variables (advanced configuration)
-  resource_prefix                           = lookup(local.connectivity_resources_advanced, "resource_prefix", local.empty_string)
-  resource_suffix                           = lookup(local.connectivity_resources_advanced, "resource_suffix", local.empty_string)
-  existing_ddos_protection_plan_resource_id = lookup(local.connectivity_resources_advanced, "existing_ddos_protection_plan_resource_id", local.empty_string)
-  existing_virtual_wan_resource_id          = lookup(local.connectivity_resources_advanced, "existing_virtual_wan_resource_id", local.empty_string)
-  existing_virtual_wan_resource_group_name  = lookup(local.connectivity_resources_advanced, "existing_virtual_wan_resource_group_name", local.empty_string)
-  resource_group_per_virtual_hub_location   = lookup(local.connectivity_resources_advanced, "resource_group_per_virtual_hub_location", false)
-  custom_azure_backup_geo_codes             = lookup(local.connectivity_resources_advanced, "custom_azure_backup_geo_codes", local.empty_map)
-  custom_settings_by_resource_type          = lookup(local.connectivity_resources_advanced, "custom_settings_by_resource_type", local.empty_map)
+  resource_prefix                                 = lookup(local.connectivity_resources_advanced, "resource_prefix", local.empty_string)
+  resource_suffix                                 = lookup(local.connectivity_resources_advanced, "resource_suffix", local.empty_string)
+  existing_ddos_protection_plan_resource_id       = lookup(local.connectivity_resources_advanced, "existing_ddos_protection_plan_resource_id", local.empty_string)
+  existing_virtual_wan_resource_id                = lookup(local.connectivity_resources_advanced, "existing_virtual_wan_resource_id", local.empty_string)
+  existing_virtual_wan_resource_group_name        = lookup(local.connectivity_resources_advanced, "existing_virtual_wan_resource_group_name", local.empty_string)
+  resource_group_per_virtual_hub_location         = lookup(local.connectivity_resources_advanced, "resource_group_per_virtual_hub_location", false)
+  custom_azure_backup_geo_codes                   = lookup(local.connectivity_resources_advanced, "custom_azure_backup_geo_codes", local.empty_map)
+  custom_privatelink_azurestaticapps_partitionids = lookup(local.connectivity_resources_advanced, "custom_privatelink_azurestaticapps_partitionids", local.empty_list)
+  custom_settings_by_resource_type                = lookup(local.connectivity_resources_advanced, "custom_settings_by_resource_type", local.empty_map)
 }

--- a/main.tf
+++ b/main.tf
@@ -82,6 +82,6 @@ module "connectivity_resources" {
   existing_virtual_wan_resource_group_name        = lookup(local.connectivity_resources_advanced, "existing_virtual_wan_resource_group_name", local.empty_string)
   resource_group_per_virtual_hub_location         = lookup(local.connectivity_resources_advanced, "resource_group_per_virtual_hub_location", false)
   custom_azure_backup_geo_codes                   = lookup(local.connectivity_resources_advanced, "custom_azure_backup_geo_codes", local.empty_map)
-  custom_privatelink_azurestaticapps_partitionids = lookup(local.connectivity_resources_advanced, "custom_privatelink_azurestaticapps_partitionids", local.empty_list)
+  custom_privatelink_azurestaticapps_partitionids = lookup(local.connectivity_resources_advanced, "custom_privatelink_azurestaticapps_partitionids", null)
   custom_settings_by_resource_type                = lookup(local.connectivity_resources_advanced, "custom_settings_by_resource_type", local.empty_map)
 }

--- a/modules/connectivity/README.md
+++ b/modules/connectivity/README.md
@@ -49,6 +49,25 @@ Type: `map(string)`
 
 Default: `{}`
 
+### <a name="input_custom_privatelink_azurestaticapps_partitionids"></a> [custom\_privatelink\_azurestaticapps\_partitionids](#input\_custom\_privatelink\_azurestaticapps\_partitionids)
+
+Description: As a uncertanty in the partition id for the azure static web app, this variable is used to specify the partition ids deployed for the azure static web app private DNS zones.  
+For more information, please refer to: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#web and https://learn.microsoft.com/en-us/azure/static-web-apps/private-endpoint
+
+Type: `list(number)`
+
+Default:
+
+```json
+[
+  1,
+  2,
+  3,
+  4,
+  5
+]
+```
+
 ### <a name="input_custom_settings_by_resource_type"></a> [custom\_settings\_by\_resource\_type](#input\_custom\_settings\_by\_resource\_type)
 
 Description: If specified, allows full customization of common settings for all resources (by type) deployed by this module.

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -12,20 +12,21 @@ locals {
 # NOTE: Need to catch error for resource_suffix when
 # no value for subscription_id is provided.
 locals {
-  enabled                                   = var.enabled
-  root_id                                   = var.root_id
-  subscription_id                           = coalesce(var.subscription_id, "00000000-0000-0000-0000-000000000000")
-  settings                                  = var.settings
-  location                                  = lower(var.location)
-  tags                                      = var.tags
-  resource_prefix                           = coalesce(var.resource_prefix, local.root_id)
-  resource_suffix                           = var.resource_suffix != local.empty_string ? "-${var.resource_suffix}" : local.empty_string
-  existing_ddos_protection_plan_resource_id = var.existing_ddos_protection_plan_resource_id
-  existing_virtual_wan_resource_id          = var.existing_virtual_wan_resource_id != null ? var.existing_virtual_wan_resource_id : local.empty_string
-  existing_virtual_wan_resource_group_name  = var.existing_virtual_wan_resource_group_name != null ? var.existing_virtual_wan_resource_group_name : local.empty_string
-  resource_group_per_virtual_hub_location   = var.resource_group_per_virtual_hub_location
-  custom_azure_backup_geo_codes             = var.custom_azure_backup_geo_codes
-  custom_settings                           = var.custom_settings_by_resource_type
+  enabled                                         = var.enabled
+  root_id                                         = var.root_id
+  subscription_id                                 = coalesce(var.subscription_id, "00000000-0000-0000-0000-000000000000")
+  settings                                        = var.settings
+  location                                        = lower(var.location)
+  tags                                            = var.tags
+  resource_prefix                                 = coalesce(var.resource_prefix, local.root_id)
+  resource_suffix                                 = var.resource_suffix != local.empty_string ? "-${var.resource_suffix}" : local.empty_string
+  existing_ddos_protection_plan_resource_id       = var.existing_ddos_protection_plan_resource_id
+  existing_virtual_wan_resource_id                = var.existing_virtual_wan_resource_id != null ? var.existing_virtual_wan_resource_id : local.empty_string
+  existing_virtual_wan_resource_group_name        = var.existing_virtual_wan_resource_group_name != null ? var.existing_virtual_wan_resource_group_name : local.empty_string
+  resource_group_per_virtual_hub_location         = var.resource_group_per_virtual_hub_location
+  custom_azure_backup_geo_codes                   = var.custom_azure_backup_geo_codes
+  custom_privatelink_azurestaticapps_partitionids = var.custom_privatelink_azurestaticapps_partitionids
+  custom_settings                                 = var.custom_settings_by_resource_type
 }
 
 # Logic to help keep code DRY
@@ -1496,7 +1497,6 @@ locals {
     azure_synapse_studio                 = ["privatelink.azuresynapse.net"]
     azure_virtual_desktop                = ["privatelink.wvd.microsoft.com"]
     azure_web_apps_sites                 = ["privatelink.azurewebsites.net", "scm.privatelink.azurewebsites.net"]
-    azure_web_apps_static_sites          = ["privatelink.azurestaticapps.net"]
     cognitive_services_account           = ["privatelink.cognitiveservices.azure.com"]
     microsoft_power_bi                   = ["privatelink.analysis.windows.net", "privatelink.pbidedicated.windows.net", "privatelink.tip1.powerquery.microsoft.com"]
     signalr                              = ["privatelink.service.signalr.net"]
@@ -1518,6 +1518,10 @@ locals {
       for location in local.private_link_locations :
       "privatelink.${location}.azmk8s.io"
     ]
+    azure_web_apps_static_sites = concat(["privatelink.azurestaticapps.net"], [
+      for partitionid in local.custom_privatelink_azurestaticapps_partitionids :
+      "privatelink.${partitionid}.azurestaticapps.net"
+    ])
   }
   # The lookup_private_link_group_id_by_service local doesn't currently
   # do anything but is planned to control policy configuration for

--- a/modules/connectivity/variables.tf
+++ b/modules/connectivity/variables.tf
@@ -369,6 +369,7 @@ DESCRIPTION
 
 variable "custom_privatelink_azurestaticapps_partitionids" {
   type        = list(number)
+  nullable    = false
   description = <<DESCRIPTION
 As a uncertanty in the partition id for the azure static web app, this variable is used to specify the partition ids deployed for the azure static web app private DNS zones.
 For more information, please refer to: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#web and https://learn.microsoft.com/en-us/azure/static-web-apps/private-endpoint

--- a/modules/connectivity/variables.tf
+++ b/modules/connectivity/variables.tf
@@ -367,6 +367,15 @@ DESCRIPTION
   default     = {}
 }
 
+variable "custom_privatelink_azurestaticapps_partitionids" {
+  type        = list(number)
+  description = <<DESCRIPTION
+As a uncertanty in the partition id for the azure static web app, this variable is used to specify the partition ids deployed for the azure static web app private DNS zones.
+For more information, please refer to: https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns#web and https://learn.microsoft.com/en-us/azure/static-web-apps/private-endpoint
+DESCRIPTION
+  default     = [1, 2, 3, 4, 5]
+}
+
 variable "custom_settings_by_resource_type" {
   type        = any
   description = "If specified, allows full customization of common settings for all resources (by type) deployed by this module."


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Azure static web apps are currently spawned without a known pattern in Public DNS zones with different partition ids in their FQDN. We are now counting [1,2,3,4,5].azurestaticapps.net with a unknown rising number.
Private DNS Zones are used for private Endpoints correspondingly (privatelink.[1,2,3,4,5].azurestaticapps.net.) and as of the CAF principals need to be known before deploying the first resources.

There is no programmatic approach known to me.

Feel free to adjust to your needs.

Examples for module calls:
```
# Adds all at PR time available: default + 1-5
configure_connectivity_resources = {
    ...
    advanced = {}
}

# Adds only zones: default + 4 + 5
configure_connectivity_resources = {
    ...
    advanced = {
      custom_privatelink_azurestaticapps_partitionids = [4, 5]
    }
}
```

## This PR fixes/adds/changes/removes

1. Adds all currently existing private DNS zones per default, when 'azure_web_apps_static_sites' is set to true.
2. Adds possibility to manually define a list of partition ids wanted. (Prohibits a breaking change when Microsoft adds a new partitionid)

### Breaking Changes

none

## Testing Evidence

- I did a plan on our current infrastructure and had no changes (all five private DNS Zone currently deployed)
- Also tested the default behavior when not setting the new variable

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
