### PR TITLE
Removed SCM privatelink since it breaks DNS resolution

### DIFF
--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1495,7 +1495,7 @@ locals {
     azure_synapse_analytics_sql          = ["privatelink.sql.azuresynapse.net"]
     azure_synapse_studio                 = ["privatelink.azuresynapse.net"]
     azure_virtual_desktop                = ["privatelink.wvd.microsoft.com"]
-    azure_web_apps_sites                 = ["privatelink.azurewebsites.net", "scm.privatelink.azurewebsites.net"]
+    azure_web_apps_sites                 = ["privatelink.azurewebsites.net"]
     azure_web_apps_static_sites          = ["privatelink.azurestaticapps.net"]
     cognitive_services_account           = ["privatelink.cognitiveservices.azure.com"]
     microsoft_power_bi                   = ["privatelink.analysis.windows.net", "privatelink.pbidedicated.windows.net", "privatelink.tip1.powerquery.microsoft.com"]


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

The introduction of scm.privatelink.azurewebsites.net DNS zone breaks DNS resolution for the SCM endpoints.
Since by default it resolves via privatelink.azurewebsites.net already, there is no reason for the SCM zone to exist.

## This PR fixes/adds/changes/removes

1. #1064

### Breaking Changes

1.  It unbreaks this breaking change.

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

It's known to work, i don't want to break my env again just to prove it :)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
