### PR TITLE
Fixes #1135 and #1136

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ This allows customers to address concerns around managing large state files, or 
 
 ## Terraform versions
 
-This module has been tested using Terraform `1.7.0` and AzureRM Provider `3.107.0` as a baseline, and various versions to up the latest at time of release.
+This module has been tested using Terraform `1.7.0` and AzureRM Provider `3.108.0` as a baseline, and various versions to up the latest at time of release.
 In some cases, individual versions of the AzureRM provider may cause errors.
 If this happens, we advise upgrading to the latest version and checking our [troubleshooting](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/wiki/Troubleshooting) guide before [raising an issue](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues).
 

--- a/_README_header.md
+++ b/_README_header.md
@@ -51,7 +51,7 @@ This allows customers to address concerns around managing large state files, or 
 
 ## Terraform versions
 
-This module has been tested using Terraform `1.7.0` and AzureRM Provider `3.107.0` as a baseline, and various versions to up the latest at time of release.
+This module has been tested using Terraform `1.7.0` and AzureRM Provider `3.108.0` as a baseline, and various versions to up the latest at time of release.
 In some cases, individual versions of the AzureRM provider may cause errors.
 If this happens, we advise upgrading to the latest version and checking our [troubleshooting](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/wiki/Troubleshooting) guide before [raising an issue](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues).
 

--- a/docs/wiki/[User-Guide]-Getting-Started.md
+++ b/docs/wiki/[User-Guide]-Getting-Started.md
@@ -3,7 +3,7 @@
 
 Before getting started with this module, please take note of the following considerations:
 
-1. This module requires a minimum `azurerm` provider version of `3.107.0`.
+1. This module requires a minimum `azurerm` provider version of `3.108.0`.
 
 1. This module requires a minimum Terraform version `1.7.0`.
 

--- a/docs/wiki/[User-Guide]-Upgrade-from-v5.2.1-to-v6.0.0.md
+++ b/docs/wiki/[User-Guide]-Upgrade-from-v5.2.1-to-v6.0.0.md
@@ -5,7 +5,7 @@ This is a major release, following the update of Azure Landing Zones with it's m
 
 ## ‼️ Breaking Changes
 
-1. Minimum AzureRM provider version now `3.107.0`
+1. Minimum AzureRM provider version now `3.108.0`
 2. Minimum Terraform version now `1.7.0`
 3. `var.configure_management_resources` schema change, removing legacy components and adding support for AMA resources
 

--- a/examples/400-multi-with-orchestration/modules/core/main.tf
+++ b/examples/400-multi-with-orchestration/modules/core/main.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.107.0"
+      version = "3.108.0"
     }
   }
 }

--- a/resources.virtual_wan.tf
+++ b/resources.virtual_wan.tf
@@ -357,6 +357,7 @@ resource "azurerm_virtual_hub_connection" "virtual_wan" {
 
   # Set explicit dependencies
   depends_on = [
+    azurerm_express_route_gateway.virtual_wan,
     azurerm_resource_group.connectivity,
     azurerm_resource_group.virtual_wan,
     azurerm_virtual_wan.virtual_wan,
@@ -382,6 +383,7 @@ resource "azurerm_virtual_hub_routing_intent" "virtual_wan" {
 
   # Set explicit dependencies
   depends_on = [
+    azurerm_express_route_gateway.virtual_wan,
     azurerm_firewall.virtual_wan,
     azurerm_resource_group.connectivity,
     azurerm_resource_group.virtual_wan,

--- a/terraform.tf
+++ b/terraform.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "~> 3.107"
+      version = "~> 3.108"
       configuration_aliases = [
         azurerm.connectivity,
         azurerm.management,

--- a/tests/README.md
+++ b/tests/README.md
@@ -151,7 +151,7 @@ The current strategy consists of running tests against the following version com
 - Terraform versions:
   - Minimum version supported by the module (`1.7.0`)
 - Azure provider for Terraform versions:
-  - Minimum version supported by the module (`v3.107.0`)
+  - Minimum version supported by the module (`v3.108.0`)
   - Latest version
 
 The latest versions are determined programmatically by querying the publisher APIs.

--- a/tests/modules/test_001_baseline/terraform.tf
+++ b/tests/modules/test_001_baseline/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.107.0"
+      version = "3.108.0"
       configuration_aliases = [
         azurerm.connectivity,
         azurerm.management,

--- a/tests/modules/test_002_add_custom_core/terraform.tf
+++ b/tests/modules/test_002_add_custom_core/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.107.0"
+      version = "3.108.0"
       configuration_aliases = [
         azurerm.connectivity,
         azurerm.management,

--- a/tests/modules/test_003_add_mgmt_conn/terraform.tf
+++ b/tests/modules/test_003_add_mgmt_conn/terraform.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "3.107.0"
+      version = "3.108.0"
       configuration_aliases = [
         azurerm.connectivity,
         azurerm.management,

--- a/tests/scripts/azp-strategy.ps1
+++ b/tests/scripts/azp-strategy.ps1
@@ -50,11 +50,11 @@ $terraformVersionsCount = $terraformVersions.Count
 
 #######################################
 # Terraform AzureRM Provider Versions
-# - Base Version: (3.107.0)
+# - Base Version: (3.108.0)
 # - Latest Versions: (latest 1)
 #######################################
 
-$azurermProviderVersionBase = "3.107.0"
+$azurermProviderVersionBase = "3.108.0"
 $azurermProviderVersionLatest = "3.116.0"
 
 #######################################


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. Fixes #1135 - Race condition results in InternalServerError when deploying in vhub a firewall, an express route gateway, vhub peering and routing intent
2. Fixes #1136 - Updating existing vnet dns_server with Azure firewall leads to azurerm_virtual_network error.
3. *Replace me*

### Breaking Changes

none

## Testing Evidence

```
module.alz_connectivity.azurerm_virtual_hub_routing_intent.virtual_wan["/subscriptions/000000/resourceGroups/rg-prod-network-vwan/providers/Microsoft.Network/virtualHubs/lz-cl-hub-southeastasia/lz-cl-routingintent-southeastasia"]: Still creating... [6m40s elapsed]
module.alz_connectivity.azurerm_virtual_hub_routing_intent.virtual_wan["/subscriptions/000000/resourceGroups/rg-prod-network-vwan/providers/Microsoft.Network/virtualHubs/lz-cl-hub-southeastasia/lz-cl-routingintent-southeastasia"]: Creation complete after 6m41s [id=/subscriptions/000000/resourceGroups/rg-prod-network-vwan/providers/Microsoft.Network/virtualHubs/lz-cl-hub-southeastasia/routingIntent/lz-cl-routingintent-southeastasia]

Apply complete! Resources: 178 added, 0 changed, 0 destroyed.
```

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
