### PR TITLE
management/log-analytics: Allow users to set a daily GB cap

### DIFF
--- a/modules/management/locals.tf
+++ b/modules/management/locals.tf
@@ -107,7 +107,7 @@ locals {
     allow_resource_only_permissions    = lookup(local.custom_settings_la_workspace, "allow_resource_only_permissions", true) # Available only in v3.36.0 onwards
     sku                                = lookup(local.custom_settings_la_workspace, "sku", "PerGB2018")
     retention_in_days                  = lookup(local.custom_settings_la_workspace, "retention_in_days", local.settings.log_analytics.config.retention_in_days)
-    daily_quota_gb                     = lookup(local.custom_settings_la_workspace, "daily_quota_gb", null)
+    daily_quota_gb                     = lookup(local.custom_settings_la_workspace, "daily_quota_gb", local.settings.log_analytics.config.daily_quota_gb)
     cmk_for_query_forced               = lookup(local.custom_settings_la_workspace, "cmk_for_query_forced", null)
     internet_ingestion_enabled         = lookup(local.custom_settings_la_workspace, "internet_ingestion_enabled", true)
     internet_query_enabled             = lookup(local.custom_settings_la_workspace, "internet_query_enabled", true)


### PR DESCRIPTION
setting `retention_in_days` worked OK, but setting `daily_quota_gb` did not. We configured the daily cap from the Azure Portal but this automation rolls it back to be disabled. This PR makes it so we can set a value for our environment, and it is not rolled back. 

```terraform
  # module.alz.azurerm_log_analytics_workspace.management["/subscriptions/96f9ca86-6842-4c2f-aada-2daafa1b0b9c/resourceGroups/redpanda-mgmt/providers/Microsoft.OperationalInsights/workspaces/redpanda-la"] will be updated in-place
  ~ resource "azurerm_log_analytics_workspace" "management" {
      ~ daily_quota_gb                          = 64 -> -1
        id                                      = "/subscriptions/96f9ca86-6842-4c2f-aada-2daafa1b0b9c/resourceGroups/redpanda-mgmt/providers/Microsoft.OperationalInsights/workspaces/redpanda-la"
        name                                    = "redpanda-la"
        tags                                    = {
            "deployedBy"   = "terraform/azure/caf-enterprise-scale"
            "redpanda-org" = "azure-governance"
        }
        # (14 unchanged attributes hidden)
    }

```