### PR TITLE
feat: ability to customise internet_security_enabled

### DIFF
--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1853,7 +1853,7 @@ locals {
           virtual_hub_id            = local.virtual_hub_resource_id[location]
           remote_virtual_network_id = spoke_resource_id
           # Optional definition attributes
-          internet_security_enabled = contains(virtual_hub_config.config.secure_spoke_virtual_network_resource_ids, spoke_resource_id)
+          internet_security_enabled = contains(virtual_hub_config.config.secure_spoke_virtual_network_resource_ids, spoke_resource_id) && !contains(virtual_hub_config.config.internet_security_disabled_ids, spoke_resource_id)
           routing                   = local.empty_list
         }
       ]

--- a/modules/connectivity/variables.tf
+++ b/modules/connectivity/variables.tf
@@ -213,6 +213,7 @@ variable "settings" {
           }), {})
           spoke_virtual_network_resource_ids        = optional(list(string), [])
           secure_spoke_virtual_network_resource_ids = optional(list(string), [])
+          internet_security_disabled_ids            = optional(list(string), [])
           enable_virtual_hub_connections            = optional(bool, false)
         })
       })

--- a/variables.tf
+++ b/variables.tf
@@ -325,6 +325,7 @@ variable "configure_connectivity_resources" {
             }), {})
             spoke_virtual_network_resource_ids        = optional(list(string), [])
             secure_spoke_virtual_network_resource_ids = optional(list(string), [])
+            internet_security_disabled_ids            = optional(list(string), [])
             enable_virtual_hub_connections            = optional(bool, false)
           })
         })


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR fixes issue 1140 (https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues/1140), whereby internet_security_enabled is configured on **every** virtual hub connection.

The changes in the PR allow a user to configure the internet_security_disabled_ids setting, where you specify any Virtual Network IDs you don't want to enable internet_security_enabled for. 

It won't affect anything 

## This PR fixes/adds/changes/removes

1. Ability to customise the internet_security_enabled setting per virtual_hub_connection. 

### Breaking Changes

N/A - no change to existing behaviour, just adds a configuration setting if the user explicitly configures it.

## Testing Evidence

![image](https://github.com/user-attachments/assets/0a593152-d5a9-4d5c-9d58-a492334307ec)

## As part of this Pull Request I have

- [ ] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [ ] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
