### PR TITLE
feat: support multiple public ips in connectivity firewall

### DIFF
--- a/README.md
+++ b/README.md
@@ -428,6 +428,7 @@ object({
                 sku_tier                      = optional(string, "Standard")
                 base_policy_id                = optional(string, "")
                 private_ip_ranges             = optional(list(string), [])
+                public_ip_count               = optional(number, 1)
                 threat_intelligence_mode      = optional(string, "Alert")
                 threat_intelligence_allowlist = optional(map(list(string)), {})
                 availability_zones = optional(object({

--- a/modules/connectivity/README.md
+++ b/modules/connectivity/README.md
@@ -229,6 +229,7 @@ object({
               sku_tier                      = optional(string, "Standard")
               base_policy_id                = optional(string, "")
               private_ip_ranges             = optional(list(string), [])
+              public_ip_count               = optional(number, 1)
               threat_intelligence_mode      = optional(string, "Alert")
               threat_intelligence_allowlist = optional(map(list(string)), {})
               availability_zones = optional(object({

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -967,11 +967,11 @@ locals {
         location            = location
         ip_configuration = try(
           local.custom_settings.azurerm_firewall["connectivity"][location].ip_configuration,
-          [
+          [for i in range(hub_network.config.azure_firewall.config.public_ip_count) :
             {
-              name                 = local.azfw_pip_name[location]
-              public_ip_address_id = local.azfw_pip_resource_id[location]
-              subnet_id            = "${local.virtual_network_resource_id[location]}/subnets/AzureFirewallSubnet"
+              name                 = i == 0 ? local.azfw_pip_name[location] : "${local.azfw_pip_name[location]}-${i + 1}"
+              public_ip_address_id = i == 0 ? local.azfw_pip_resource_id[location] : "${local.azfw_pip_resource_id[location]}-${i + 1}"
+              subnet_id            = i == 0 ? "${local.virtual_network_resource_id[location]}/subnets/AzureFirewallSubnet" : null
             }
           ]
         )
@@ -1041,12 +1041,12 @@ locals {
           concat(
             length(try(local.custom_settings.azurerm_firewall["connectivity"][location].ip_configuration, local.empty_map)) > 0
             ? local.empty_list
-            : [{
+            : [for i in range(hub_network.config.azure_firewall.config.public_ip_count) : {
               # Resource logic attributes
-              resource_id       = local.azfw_pip_resource_id[location]
+              resource_id       = i == 0 ? local.azfw_pip_resource_id[location] : "${local.azfw_pip_resource_id[location]}-${i + 1}"
               managed_by_module = local.deploy_azure_firewall[location]
               # Resource definition attributes
-              name                    = local.azfw_pip_name[location]
+              name                    = i == 0 ? local.azfw_pip_name[location] : "${local.azfw_pip_name[location]}-${i + 1}"
               resource_group_name     = local.resource_group_names_by_scope_and_location["connectivity"][location]
               location                = location
               zones                   = local.azfw_pip_zones[location]

--- a/modules/connectivity/variables.tf
+++ b/modules/connectivity/variables.tf
@@ -127,6 +127,7 @@ variable "settings" {
               sku_tier                      = optional(string, "Standard")
               base_policy_id                = optional(string, "")
               private_ip_ranges             = optional(list(string), [])
+              public_ip_count               = optional(number, 1)
               threat_intelligence_mode      = optional(string, "Alert")
               threat_intelligence_allowlist = optional(map(list(string)), {})
               availability_zones = optional(object({

--- a/variables.tf
+++ b/variables.tf
@@ -240,6 +240,7 @@ variable "configure_connectivity_resources" {
                 sku_tier                      = optional(string, "Standard")
                 base_policy_id                = optional(string, "")
                 private_ip_ranges             = optional(list(string), [])
+                public_ip_count               = optional(number, 1)
                 threat_intelligence_mode      = optional(string, "Alert")
                 threat_intelligence_allowlist = optional(map(list(string)), {})
                 availability_zones = optional(object({


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR gives the possibility to the connectivity module the option to specify how many public IPs you want to have deployed as part of your landing zone.

The default is set to be one, but when specifying more, you get multiple IPs provisioned and associated with the firewall in the hub_network.

The naming of azurerm_public_ip resource are _-pip_, _-pip-2_, _pip-3_ and so on, so nothing gets removed.

## This PR fixes/adds/changes/removes

1. fixes #1083
2. fixes #879

## Breaking Changes

None.

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

```terraform
Terraform will perform the following actions:

  # module.enterprise_scale.azurerm_firewall.connectivity["/subscriptions/<subscription-id>/resourceGroups/myalz-connectivity-swedencentral/providers/Microsoft.Network/azureFirewalls/myalz-fw-swedencentral"] will be updated in-place
  ~ resource "azurerm_firewall" "connectivity" {
        id                  = "/subscriptions/<subscription-id>/resourceGroups/myalz-connectivity-swedencentral/providers/Microsoft.Network/azureFirewalls/myalz-fw-swedencentral"
        name                = "myalz-fw-swedencentral"
        tags                = {
            "deployedBy"   = "terraform/azure/caf-enterprise-scale"
        }
        # (10 unchanged attributes hidden)

      + ip_configuration {
          + name                 = "myalz-fw-swedencentral-pip-2"
          + public_ip_address_id = "/subscriptions/<subscription-id>/resourceGroups/myalz-connectivity-swedencentral/providers/Microsoft.Network/publicIPAddresses/myalz-fw-swedencentral-pip-2"
        }

        # (2 unchanged blocks hidden)
    }

  # module.enterprise_scale.azurerm_public_ip.connectivity["/subscriptions/<subscription-id>/resourceGroups/myalz-connectivity-swedencentral/providers/Microsoft.Network/publicIPAddresses/myalz-fw-swedencentral-pip-2"] will be created
  + resource "azurerm_public_ip" "connectivity" {
      + allocation_method       = "Static"
      + ddos_protection_mode    = "VirtualNetworkInherited"
      + fqdn                    = (known after apply)
      + id                      = (known after apply)
      + idle_timeout_in_minutes = 4
      + ip_address              = (known after apply)
      + ip_version              = "IPv4"
      + location                = "swedencentral"
      + name                    = "myalz-fw-swedencentral-pip-2"
      + resource_group_name     = "myalz-connectivity-swedencentral"
      + sku                     = "Standard"
      + sku_tier                = "Regional"
      + tags                    = {
          + "deployedBy"   = "terraform/azure/caf-enterprise-scale"
        }
      + zones                   = [
          + "1",
          + "2",
          + "3",
        ]
    }

Plan: 1 to add, 1 to change, 0 to destroy.
```

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
