### PR TITLE
feat: Update Deny to Aine-CognitiveSearch-Cmk incl. param default values

### DIFF
--- a/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_enforce_encryption_cmk.tmpl.json
+++ b/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_enforce_encryption_cmk.tmpl.json
@@ -226,10 +226,9 @@
       },
       "cognitiveSearchCmk": {
         "type": "string",
-        "defaultValue": "Deny",
+        "defaultValue": "AuditIfNotExists",
         "allowedValues": [
-          "Audit",
-          "Deny",
+          "AuditIfNotExists",
           "Disabled"
         ]
       },
@@ -495,6 +494,16 @@
         "groupNames": []
       },
       {
+        "policyDefinitionReferenceId": "Aine-CognitiveSearch-Cmk",
+        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/76a56461-9dc0-40f0-82f5-2453283afa2f",
+        "parameters": {
+          "effect": {
+            "value": "[parameters('cognitiveSearchCmk')]"
+          }
+        },
+        "groupNames": []
+      },
+      {
         "policyDefinitionReferenceId": "Deny-Aa-Cmk",
         "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/56a5ee18-2ae6-4810-86f7-18e39ce5629b",
         "parameters": {
@@ -510,16 +519,6 @@
         "parameters": {
           "effect": {
             "value": "[parameters('BackupCmkEffect')]"
-          }
-        },
-        "groupNames": []
-      },
-      {
-        "policyDefinitionReferenceId": "Deny-CognitiveSearch-Cmk",
-        "policyDefinitionId": "/providers/Microsoft.Authorization/policyDefinitions/76a56461-9dc0-40f0-82f5-2453283afa2f",
-        "parameters": {
-          "effect": {
-            "value": "[parameters('cognitiveSearchCmk')]"
           }
         },
         "groupNames": []


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR fixes/adds/changes/removes

1. Aligns Policy Set `Enforce-Encryption-CMK` with new default and available options (major change at [AzAdvertizer](https://www.azadvertizer.net/azpolicyadvertizer/76a56461-9dc0-40f0-82f5-2453283afa2f.html). The `policyDefinitionReferenceId` has been changed from `Deny` to `Aine` and has been moved in the file.
2. fixes #1248 

### Breaking Changes

None, restores the Module to work again.

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

We (@Nide27) were able to roll out the Module by changing the source to my fork including the changes. `37 added` are the resources after the crashes at the policy.

![image](https://github.com/user-attachments/assets/71cd4b7f-d31c-4a30-be26-6c993421724e)

![image](https://github.com/user-attachments/assets/eba3f91a-cb5f-41c4-a735-0f210cf62431)

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
