### PR TITLE
Fix Enforce-Encryption-CMK default value

### DIFF
--- a/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_enforce_encryption_cmk.tmpl.json
+++ b/modules/archetypes/lib/policy_set_definitions/policy_set_definition_es_enforce_encryption_cmk.tmpl.json
@@ -226,10 +226,9 @@
       },
       "cognitiveSearchCmk": {
         "type": "string",
-        "defaultValue": "Deny",
+        "defaultValue": "AuditIfNotExists",
         "allowedValues": [
-          "Audit",
-          "Deny",
+          "AuditIfNotExists",
           "Disabled"
         ]
       },


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This pull request has been created in order to fix the `'Enforce-Encryption-CMK' could not be parameterized` error when running the module. This error seems to pop up on old and new deployments and currently requires the user to overwrite the `policy_set_definition_es_enforce_encryption_cmk.tmpl.json` file manually. Here the value `deny` must be removed. This error probably appeared because of a change on Azure.

## This PR fixes

1. `"The policy set 'Enforce-Encryption-CMK' could not be parameterized because the default value of a policy set parameter referenced by policy definition 76a56461-9dc0-40f0-82f5-2453283afa2f was not valid for that policy definition.` error message when deploying using the level 100 caf model.

### Breaking Changes

This pull request solves a breaking change. However if for some reason old `Deny` value was used and is still working this pull request will break it (However I highly doubt it when looking at the error message).

## Testing Evidence

When this file is run with Terraform the above mentioned error that the definition `76a56461-9dc0-40f0-82f5-2453283afa2f (cognitiveSearchCmk)` cannot have the value `Deny` will not show up and will show a succesfull plan as usual.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [ ] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
