### PR TITLE
feat: deploy private dns zone and private dns zone virtual network link for managed prometheus

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,6 +572,7 @@ object({
             azure_machine_learning_workspace     = optional(bool, true)
             azure_managed_disks                  = optional(bool, true)
             azure_managed_grafana                = optional(bool, true)
+            azure_managed_prometheus             = optional(bool, true)
             azure_media_services                 = optional(bool, true)
             azure_migrate                        = optional(bool, true)
             azure_monitor                        = optional(bool, true)

--- a/modules/connectivity/README.md
+++ b/modules/connectivity/README.md
@@ -373,6 +373,7 @@ object({
           azure_machine_learning_workspace     = optional(bool, true)
           azure_managed_disks                  = optional(bool, true)
           azure_managed_grafana                = optional(bool, true)
+          azure_managed_prometheus             = optional(bool, true)
           azure_media_services                 = optional(bool, true)
           azure_migrate                        = optional(bool, true)
           azure_monitor                        = optional(bool, true)

--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1515,6 +1515,10 @@ locals {
       for location in local.private_link_locations :
       "privatelink.${location}.azmk8s.io"
     ]
+    azure_managed_prometheus = [
+      for location in local.private_link_locations :
+      "privatelink.${location}.prometheus.monitor.azure.com"
+    ]
     azure_web_apps_static_sites = concat(["privatelink.azurestaticapps.net"], [
       for partitionid in local.custom_privatelink_azurestaticapps_partitionids :
       "privatelink.${partitionid}.azurestaticapps.net"

--- a/modules/connectivity/variables.tf
+++ b/modules/connectivity/variables.tf
@@ -271,6 +271,7 @@ variable "settings" {
           azure_machine_learning_workspace     = optional(bool, true)
           azure_managed_disks                  = optional(bool, true)
           azure_managed_grafana                = optional(bool, true)
+          azure_managed_prometheus             = optional(bool, true)
           azure_media_services                 = optional(bool, true)
           azure_migrate                        = optional(bool, true)
           azure_monitor                        = optional(bool, true)

--- a/variables.tf
+++ b/variables.tf
@@ -384,6 +384,7 @@ variable "configure_connectivity_resources" {
             azure_machine_learning_workspace     = optional(bool, true)
             azure_managed_disks                  = optional(bool, true)
             azure_managed_grafana                = optional(bool, true)
+            azure_managed_prometheus             = optional(bool, true)
             azure_media_services                 = optional(bool, true)
             azure_migrate                        = optional(bool, true)
             azure_monitor                        = optional(bool, true)


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This pull request includes changes to add Private DNS zone and Private DNS zone Virtual Network Link for Azure Managed Prometheus by the connectivity-module. The most important changes include updates to the `README.md`, `modules/connectivity/README.md`, `modules/connectivity/locals.tf`, `modules/connectivity/variables.tf`, and `variables.tf` files.

Add support for Private DNS zone and Private DNS zone Virtual Network Link for Managed Prometheus:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R575): Added `azure_managed_prometheus` as an optional boolean setting.
* [`modules/connectivity/README.md`](diffhunk://#diff-d64809a58a4d29b9843846e4f0ee9a5f977447bfa37b4eccbd9dd5e041847d5cR376): Included `azure_managed_prometheus` in the list of optional boolean settings.
* [`modules/connectivity/locals.tf`](diffhunk://#diff-1db17ddb4fd5ac32cf26aaedeca0f71eeca2a3fc543e73bb3cb71626296b2cabR1518-R1521): Defined `azure_managed_prometheus` with private link locations.
* [`modules/connectivity/variables.tf`](diffhunk://#diff-87e434e445bc85567a6a89bea320c3280a9cf8f60237e463d133c4fc825ee73aR274): Added `azure_managed_prometheus` to the `settings` variable.
* [`variables.tf`](diffhunk://#diff-05b5a57c136b6ff596500bcbfdcff145ef6cddea2a0e86d184d9daa9a65a288eR387): Included `azure_managed_prometheus` in the `configure_connectivity_resources` variable.

## This PR fixes/adds/changes/removes

N/A

### Breaking Changes

N/A

## Testing Evidence

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

```terraform
Terraform will perform the following actions:

  # module.enterprise_scale.azurerm_private_dns_zone.connectivity["/subscriptions/<subscription-id>/resourceGroups/myalz-connectivity-swedencentral/providers/Microsoft.Network/privateDnsZones/privatelink.swedencentral.prometheus.monitor.azure.com"] will be created
  + resource "azurerm_private_dns_zone" "connectivity" {
      + id                                                    = (known after apply)
      + max_number_of_record_sets                             = (known after apply)
      + max_number_of_virtual_network_links                   = (known after apply)
      + max_number_of_virtual_network_links_with_registration = (known after apply)
      + name                                                  = "privatelink.swedencentral.prometheus.monitor.azure.com"
      + number_of_record_sets                                 = (known after apply)
      + resource_group_name                                   = "myalz-connectivity-swedencentral"
      + tags                                                  = {
          + "deployedBy" = "terraform/azure/caf-enterprise-scale"
        }

      + soa_record (known after apply)

      + timeouts {}
    }

  # module.enterprise_scale.azurerm_private_dns_zone_virtual_network_link.connectivity["/subscriptions/<subscription-id>/resourceGroups/myalz-connectivity-swedencentral/providers/Microsoft.Network/privateDnsZones/privatelink.swedencentral.prometheus.monitor.azure.com/virtualNetworkLinks/<subscription-id>-<random-id>"] will be created
  + resource "azurerm_private_dns_zone_virtual_network_link" "connectivity" {
      + id                    = (known after apply)
      + name                  = "<subscription-id>-<random-id>"
      + private_dns_zone_name = "privatelink.swedencentral.prometheus.monitor.azure.com"
      + registration_enabled  = false
      + resource_group_name   = "myalz-connectivity-swedencentral"
      + tags                  = {
          + "deployedBy" = "terraform/azure/caf-enterprise-scale"
        }
      + virtual_network_id    = "/subscriptions/<subscription-id>/resourceGroups/myalz-connectivity-swedencentral/providers/Microsoft.Network/virtualNetworks/myalz-hub-swedencentral"

      + timeouts {}
    }

Plan: 2 to add, 0 to change, 0 to destroy.
```

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
