### PR TITLE
Update [User-Guide]-Upgrade-from-v5.2.1-to-v6.0.0.md

### DIFF
--- a/docs/wiki/[User-Guide]-Upgrade-from-v5.2.1-to-v6.0.0.md
+++ b/docs/wiki/[User-Guide]-Upgrade-from-v5.2.1-to-v6.0.0.md
@@ -29,7 +29,7 @@ We deploy AMA resources using the new `configure_management_resources` variable.
 
 ### New resources
 
-- A user-assigned managed identity (UAMI) for the AMA agent to authenticate with Azure Monitor (this needs no special tole assignments, any valid identity will suffice)
+- A user-assigned managed identity (UAMI) for the AMA agent to authenticate with Azure Monitor (this needs no special role assignments, any valid identity will suffice)
 - Data collection rule for VM Insights
 - Data collection rule for Change Tracking
 - Data collection rule for Defender for SQL


### PR DESCRIPTION
This PR corrects a typo in the documentation where "tole" was used instead of "role." The change ensures clarity and maintains the professionalism of the document.  

Changes Made:  
- Replaced "tole" with "role" in line 32.
