### PR TITLE
New feature - Add possibility to overwrite default outbound access enabled setting for subnets

### DIFF
--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -424,6 +424,7 @@ locals {
             service_endpoints                             = try(local.custom_settings.azurerm_subnet["connectivity"][location][subnet.name].service_endpoints, null)
             service_endpoint_policy_ids                   = try(local.custom_settings.azurerm_subnet["connectivity"][location][subnet.name].service_endpoint_policy_ids, null)
             delegation                                    = try(local.custom_settings.azurerm_subnet["connectivity"][location][subnet.name].delegation, local.empty_list)
+            default_outbound_access_enabled               = try(local.custom_settings.azurerm_subnet["connectivity"][location][subnet.name].default_outbound_access_enabled, true)
           }
         )
       ],
@@ -444,6 +445,7 @@ locals {
           service_endpoints                             = try(local.custom_settings.azurerm_subnet["connectivity"][location]["GatewaySubnet"].service_endpoints, null)
           service_endpoint_policy_ids                   = try(local.custom_settings.azurerm_subnet["connectivity"][location]["GatewaySubnet"].service_endpoint_policy_ids, null)
           delegation                                    = try(local.custom_settings.azurerm_subnet["connectivity"][location]["GatewaySubnet"].delegation, local.empty_list)
+          default_outbound_access_enabled               = try(local.custom_settings.azurerm_subnet["connectivity"][location]["GatewaySubnet"].default_outbound_access_enabled, true)
         }
       ] : local.empty_list,
       # Conditionally add Azure Firewall subnet
@@ -463,6 +465,7 @@ locals {
           service_endpoints                             = try(local.custom_settings.azurerm_subnet["connectivity"][location]["AzureFirewallSubnet"].service_endpoints, null)
           service_endpoint_policy_ids                   = try(local.custom_settings.azurerm_subnet["connectivity"][location]["AzureFirewallSubnet"].service_endpoint_policy_ids, null)
           delegation                                    = try(local.custom_settings.azurerm_subnet["connectivity"][location]["AzureFirewallSubnet"].delegation, local.empty_list)
+          default_outbound_access_enabled               = try(local.custom_settings.azurerm_subnet["connectivity"][location]["AzureFirewallSubnet"].default_outbound_access_enabled, true)
         }
       ] : local.empty_list,
       # Conditionally add Azure Firewall Management Subnet
@@ -482,6 +485,7 @@ locals {
           service_endpoints                             = try(local.custom_settings.azurerm_subnet["connectivity"][location]["AzureFirewallManagementSubnet"].service_endpoints, null)
           service_endpoint_policy_ids                   = try(local.custom_settings.azurerm_subnet["connectivity"][location]["AzureFirewallManagementSubnet"].service_endpoint_policy_ids, null)
           delegation                                    = try(local.custom_settings.azurerm_subnet["connectivity"][location]["AzureFirewallManagementSubnet"].delegation, local.empty_list)
+          default_outbound_access_enabled               = try(local.custom_settings.azurerm_subnet["connectivity"][location]["AzureFirewallManagementSubnet"].default_outbound_access_enabled, true)
         }
       ] : local.empty_list,
 

--- a/resources.connectivity.tf
+++ b/resources.connectivity.tf
@@ -53,6 +53,7 @@ resource "azurerm_subnet" "connectivity" {
   resource_group_name  = each.value.template.resource_group_name
   virtual_network_name = each.value.template.virtual_network_name
   address_prefixes     = each.value.template.address_prefixes
+  default_outbound_access_enabled = each.value.template.default_outbound_access_enabled
 
   # Optional resource attributes
   private_link_service_network_policies_enabled = each.value.template.private_link_service_network_policies_enabled


### PR DESCRIPTION
 <!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

This PR is a workaround to problem with default_outbound_access_enabled=true 
It's allowing users to use advanced settings to overwrite default values for Out of the box subnets:
"GatewaySubnet", "AzureFirewallSubnet" and "AzureFirewallManagementSubnet" and also for custom ones. 

## This PR fixes/adds/changes/removes

1. *Support to overwrite default settings for default_outbound_access_enabled in all Enterprise Scale subnets*

### Breaking Changes

1.  #*None*

## Testing Evidence
Azure/Azure-Landing-Zones#450 

I tested this PR in my test environment. I was able to overwrite default settings with 

```
                "GatewaySubnet" = {
                  default_outbound_access_enabled = false
                },
                "AzureFirewallSubnet" = {
                  default_outbound_access_enabled = false
                }
```

Please provide any testing evidence to show that your Pull Request works/fixes as described and planned (include screenshots, if appropriate).

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [ ] Performed testing and provided evidence.
- [ ] Updated relevant and associated documentation.
