### PR TITLE
Added an option to enable bgp_route_translation_for_nat in vHub VPN Gateway

### DIFF
--- a/modules/connectivity/locals.tf
+++ b/modules/connectivity/locals.tf
@@ -1406,6 +1406,7 @@ locals {
         }
       ]
     }
+    bgp_route_translation_for_nat_enabled = virtual_hub.config.vpn_gateway.config.bgp_route_translation_for_nat_enabled
   ]
 }
 

--- a/modules/connectivity/variables.tf
+++ b/modules/connectivity/variables.tf
@@ -192,6 +192,7 @@ variable "settings" {
               ), [])
               routing_preference = optional(string, "Microsoft Network")
               scale_unit         = optional(number, 1)
+              bgp_route_translation_for_nat_enabled = optional(bool, false)
             }), {})
           }), {})
           azure_firewall = optional(object({

--- a/resources.virtual_wan.tf
+++ b/resources.virtual_wan.tf
@@ -110,7 +110,8 @@ resource "azurerm_vpn_gateway" "virtual_wan" {
   routing_preference = each.value.template.routing_preference
   scale_unit         = each.value.template.scale_unit
   tags               = each.value.template.tags
-
+  bgp_route_translation_for_nat_enabled = each.value.template.bgp_route_translation_for_nat_enabled
+  
   # Dynamic configuration blocks
   dynamic "bgp_settings" {
     for_each = each.value.template.bgp_settings

--- a/variables.tf
+++ b/variables.tf
@@ -305,6 +305,7 @@ variable "configure_connectivity_resources" {
                 ), [])
                 routing_preference = optional(string, "Microsoft Network")
                 scale_unit         = optional(number, 1)
+                bgp_route_translation_for_nat_enabled = optional(bool, false)
               }), {})
             }), {})
             azure_firewall = optional(object({


### PR DESCRIPTION
<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Replace this with a brief description of what this Pull Request fixes, changes, etc.

## This PR changes

1. VPN Gateway config so it supports "Enable Bgp Route Translation" in a "NAT Rules" of a "VPN Gateway" in a vWan vHUB


### Breaking Changes

1. Added "bgp_route_translation_for_nat_enabled = virtual_hub.config.vpn_gateway.config.bgp_route_translation_for_nat_enabled" on the connectivity module, inside locals.tf to add the missing module in the locals
2. Added cariable on the connectivity module "bgp_route_translation_for_nat_enabled = optional(bool, false)" to support adding this value inside of TF code
3. Added the same variable inside the general variables of the CAF module "bgp_route_translation_for_nat_enabled = optional(bool, false)"
4. Added "bgp_route_translation_for_nat_enabled = each.value.template.bgp_route_translation_for_nat_enabled" inside the resource definition for "azurerm_vpn_gateway" on the resources.virtual_wan, on the foreach loop

## Testing Evidence

We already have this option enabled on one of our VPN Gateways, so when i tried with option commented out or by setting it to false i get:
![bgp_RT_nat_disabled](https://github.com/user-attachments/assets/41d3db1f-0879-4654-83f0-8a112721d7ac)



When i tried setting it to true, no changes on the VPN Gateway:
![bgp_RT_nat_enabled](https://github.com/user-attachments/assets/b11f0f27-2128-4bf8-b0e4-0e40e7caea62)



## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [x] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.

@microsoft-github-policy-service agree [company="Apex Group Ltd."]
@microsoft-github-policy-service agree company="Microsoft"