### PR TITLE
Fixes #1309: Change effect value from 'deny' to 'Deny'

### DIFF
--- a/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_priv_esc_aks.tmpl.json
+++ b/modules/archetypes/lib/policy_assignments/policy_assignment_es_deny_priv_esc_aks.tmpl.json
@@ -11,7 +11,7 @@
     "enforcementMode": "Default",
     "parameters": {
       "effect": {
-        "value": "deny"
+        "value": "Deny"
       }
     },
     "scope": "${current_scope_resource_id}",


### PR DESCRIPTION
Correct value mismatch for built-in policy allowed values.

<!-- markdownlint-disable first-line-h1 -->

<!-- Thank you for submitting a Pull Request. Please fill out the template below.-->
## Overview/Summary

Deploying ALZ to a greenfield environment wouldn't pass due to the error from ARM. Updated the policy and deployment now passes without error.

## This PR fixes/adds/changes/removes

1. Updates the passed value from 'deny' to 'Deny'

### Breaking Changes

_None._

## Testing Evidence

Tested in greenfield environment.

## As part of this Pull Request I have

- [x] Checked for duplicate [Pull Requests](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/pulls)
- [x] Associated it with relevant [issues](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/issues), for tracking and closure.
- [X] Ensured my code/branch is up-to-date with the latest changes in the `main` [branch](https://github.com/Azure/terraform-azurerm-caf-enterprise-scale/tree/main)
- [x] Performed testing and provided evidence.
- [x] Updated relevant and associated documentation.
